### PR TITLE
Remvove country from hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
     "name": "Garmin Connect",
-    "country": "NL",
     "render_readme": true,
     "domains": ["sensor"]
   }


### PR DESCRIPTION
The NL specifier in the hacs.json is causing the integration to not be available in other countries.  This removes it.