### PR TITLE
Gear sensor & Gear Service

### DIFF
--- a/custom_components/garmin_connect/__init__.py
+++ b/custom_components/garmin_connect/__init__.py
@@ -14,10 +14,16 @@ from garminconnect import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, IntegrationError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DATA_COORDINATOR, DEFAULT_UPDATE_INTERVAL, DOMAIN
+from .const import (
+    DATA_COORDINATOR,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    GEAR,
+    SERVICE_SETTING,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,12 +41,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_COORDINATOR: coordinator,
-    }
+    hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: coordinator}
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-
     return True
 
 
@@ -100,15 +103,18 @@ class GarminConnectDataUpdateCoordinator(DataUpdateCoordinator):
             )
             alarms = await self.hass.async_add_executor_job(self._api.get_device_alarms)
             gear = await self.hass.async_add_executor_job(
-                self._api.get_gear, summary["userProfileId"]
+                self._api.get_gear, summary[GEAR.USERPROFILE_ID]
             )
             tasks: list[Awaitable] = [
                 self.hass.async_add_executor_job(
-                    self._api.get_gear_stats, gear_item["uuid"]
+                    self._api.get_gear_stats, gear_item[GEAR.UUID]
                 )
                 for gear_item in gear
             ]
             gear_stats = await asyncio.gather(*tasks)
+            activity_types = await self.hass.async_add_executor_job(
+                self._api.get_activity_types
+            )
         except (
             GarminConnectAuthenticationError,
             GarminConnectTooManyRequestsError,
@@ -125,4 +131,46 @@ class GarminConnectDataUpdateCoordinator(DataUpdateCoordinator):
             "nextAlarm": alarms,
             "gear": gear,
             "gear_stats": gear_stats,
+            "activity_types": activity_types,
         }
+
+    async def set_active_gear(self, entity, service_data):
+        """Update Garmin Gear settings"""
+        if not await self.async_login():
+            raise IntegrationError(
+                "Failed to login to Garmin Connect, unable to update"
+            )
+
+        setting = service_data.data["setting"]
+        activity_type_id = next(
+            filter(
+                lambda a: a[GEAR.TYPE_KEY] == service_data.data["activity_type"],
+                self.data["activity_types"],
+            )
+        )[GEAR.TYPE_ID]
+        if setting != SERVICE_SETTING.ONLY_THIS_AS_DEFAULT:
+            await self._api.set_gear_default(
+                activity_type_id, entity.uuid, setting == SERVICE_SETTING.DEFAULT
+            )
+        else:
+            old_default_state = await self.hass.async_add_executor_job(
+                self._api.get_gear_defaults, self.data[GEAR.USERPROFILE_ID]
+            )
+            to_deactivate = list(
+                filter(
+                    lambda o: o[GEAR.ACTIVITY_TYPE_PK] == activity_type_id
+                    and o[GEAR.UUID] != entity.uuid,
+                    old_default_state,
+                )
+            )
+
+            for active_gear in to_deactivate:
+                await self.hass.async_add_executor_job(
+                    self._api.set_gear_default,
+                    activity_type_id,
+                    active_gear[GEAR.UUID],
+                    False,
+                )
+            await self.hass.async_add_executor_job(
+                self._api.set_gear_default, activity_type_id, entity.uuid, True
+            )

--- a/custom_components/garmin_connect/const.py
+++ b/custom_components/garmin_connect/const.py
@@ -1,5 +1,7 @@
 """Constants for the Garmin Connect integration."""
 from datetime import timedelta
+from enum import Enum
+from typing import NamedTuple
 
 from homeassistant.const import (
     DEVICE_CLASS_TIMESTAMP,
@@ -361,3 +363,19 @@ GEAR_ICONS = {
     "Other": "mdi:basketball",
     "Golf Clubs": "mdi:golf",
 }
+
+
+class SERVICE_SETTING(NamedTuple):
+    """Options for the service settings, see services.yaml"""
+
+    ONLY_THIS_AS_DEFAULT = "set this as default, unset others"
+    DEFAULT = "set as default"
+    UNSET_DEFAULT = "unset default"
+
+
+class GEAR(NamedTuple):
+    UUID = "uuid"
+    TYPE_KEY = "typeKey"
+    TYPE_ID = "typeId"
+    USERPROFILE_ID = "userProfileId"
+    ACTIVITY_TYPE_PK = "activityTypePk"

--- a/custom_components/garmin_connect/const.py
+++ b/custom_components/garmin_connect/const.py
@@ -354,3 +354,10 @@ GARMIN_ENTITY_LIST = {
     "metabolicAge": ["Metabolic Age", TIME_YEARS, "mdi:calendar-heart", None, False],
     "nextAlarm": ["Next Alarm Time", None, "mdi:alarm", None, True],
 }
+
+GEAR_ICONS = {
+    "Shoes": "mdi:shoe-sneaker",
+    "Bike": "mdi:bike",
+    "Other": "mdi:basketball",
+    "Golf Clubs": "mdi:golf",
+}

--- a/custom_components/garmin_connect/manifest.json
+++ b/custom_components/garmin_connect/manifest.json
@@ -3,7 +3,9 @@
   "name": "Garmin Connect",
   "documentation": "https://github.com/cyberjunky/home-assistant-garmin_connect",
   "issue_tracker": "https://github.com/cyberjunky/home-assistant-garmin_connect/issues",
-  "requirements": ["garminconnect==0.1.24"],
+  "requirements": [
+    "git+https://github.com/ray0711/python-garminconnect.git#garminconnect==0.1.50"
+  ],
   "codeowners": ["@cyberjunky"],
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -2,12 +2,11 @@
 from __future__ import annotations
 
 import logging
-from operator import itemgetter
+from numbers import Number
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_ATTRIBUTION,
     CONF_ID,
     DEVICE_CLASS_TIMESTAMP,
     LENGTH_KILOMETERS,
@@ -135,7 +134,7 @@ class GarminConnectSensor(CoordinatorEntity, SensorEntity):
         if self._device_class == DEVICE_CLASS_TIMESTAMP:
             return value
 
-        return round(value, 2)
+        return round(value, 2) if isinstance(value, Number) else value
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -2,10 +2,16 @@
 from __future__ import annotations
 
 import logging
+from operator import itemgetter
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_ID, DEVICE_CLASS_TIMESTAMP
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    CONF_ID,
+    DEVICE_CLASS_TIMESTAMP,
+    LENGTH_KILOMETERS,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -18,6 +24,7 @@ from .const import (
     DATA_COORDINATOR,
     DOMAIN as GARMIN_DOMAIN,
     GARMIN_ENTITY_LIST,
+    GEAR_ICONS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,6 +64,19 @@ async def async_setup_entry(
                 icon,
                 device_class,
                 enabled_by_default,
+            )
+        )
+
+    for gear_item in coordinator.data["gear"]:
+        entities.append(
+            GarminConnectGearSensor(
+                coordinator,
+                unique_id,
+                gear_item["uuid"],
+                gear_item["gearTypeName"],
+                gear_item["displayName"],
+                None,
+                True,
             )
         )
 
@@ -155,3 +175,100 @@ class GarminConnectSensor(CoordinatorEntity, SensorEntity):
             and self.coordinator.data
             and self._type in self.coordinator.data
         )
+
+
+class GarminConnectGearSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a Garmin Connect Sensor."""
+
+    def __init__(
+        self,
+        coordinator,
+        unique_id,
+        uuid,
+        sensor_type,
+        name,
+        device_class: None,
+        enabled_default: bool = True,
+    ):
+        """Initialize a Garmin Connect sensor."""
+        super().__init__(coordinator)
+
+        self._unique_id = unique_id
+        self._type = sensor_type
+        self._uuid = uuid
+        self._device_class = device_class
+        self._enabled_default = enabled_default
+
+        self._attr_name = name
+        self._attr_device_class = self._device_class
+        self._attr_icon = GEAR_ICONS[sensor_type]
+        self._attr_native_unit_of_measurement = LENGTH_KILOMETERS
+        self._attr_unique_id = f"{self._unique_id}_{self._uuid}"
+        self._attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        if not self.coordinator.data or not self.get_stats():
+            return None
+
+        value = self.get_stats()["totalDistance"]
+        return round(value / 1000, 2)
+
+    @property
+    def extra_state_attributes(self):
+        """Return attributes for sensor."""
+        gear = self.get_gear()
+        stats = self.get_stats()
+
+        if not self.coordinator.data or not gear or not stats:
+            return {}
+
+        attributes = {
+            "last_synced": self.coordinator.data["lastSyncTimestampGMT"],
+            "total_activities": stats["totalActivities"],
+            "create_date": stats["createDate"],
+            "update_date": stats["updateDate"],
+            "date_begin": gear["dateBegin"],
+            "date_end": gear["dateEnd"],
+            "gear_make_name": gear["gearMakeName"],
+            "gear_model_name": gear["gearModelName"],
+            "gear_status_name": gear["gearStatusName"],
+            "custom_make_model": gear["customMakeModel"],
+            "maximum_meters": gear["maximumMeters"],
+        }
+        return attributes
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        return {
+            "identifiers": {(GARMIN_DOMAIN, self._unique_id)},
+            "name": "Garmin Connect",
+            "manufacturer": "Garmin Connect",
+        }
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return self._enabled_default
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return (
+            super().available
+            and self.coordinator.data
+            and self.get_gear()
+            # and any(g["uuid"] == self._uuid for g in self.coordinator.data["gear"])
+        )
+
+    def get_stats(self):
+        for gear_stats_item in self.coordinator.data["gear_stats"]:
+            if gear_stats_item["uuid"] == self._uuid:
+                return gear_stats_item
+
+    def get_gear(self):
+        for gear_item in self.coordinator.data["gear"]:
+            if gear_item["uuid"] == self._uuid:
+                return gear_item

--- a/custom_components/garmin_connect/services.yaml
+++ b/custom_components/garmin_connect/services.yaml
@@ -1,0 +1,39 @@
+set_active_gear:
+  name: Set active gear for activity
+  # target:
+  #   entity:
+  #     integration: "garmin_connect"
+  fields:
+    activity_type:
+      required: true
+      name: activity type
+      description: garmin activity type
+      example: running
+      default: running
+      selector:
+        select:
+          options:
+            - running
+            - cycling
+            - hiking
+            - other
+            - walking
+            - swimming
+    setting:
+      required: true
+      name: setting
+      description: gear setting to apply
+      default: set this as default, unset others
+      selector:
+        select:
+          options:
+            - set this as default, unset others
+            - set as default
+            - unset default
+    entity_id:
+      description: entity
+      required: true
+      selector:
+        entity:
+          integration: garmin_connect
+          device_class: Gear


### PR DESCRIPTION
**Request for feedback / testing**

Hi @cyberjunky,
this PR is not yet production ready. In a short test the house didn't explode and garmin didn't lock me out immediately. Still it deserves a bit more testing and maybe you have some input on how to organize it all better?

With this code you should get a sensor per gear item with the usage distance. With the service the active default gear per activity type can be set. I plan to use it with nfc tags in the running shoes to track the milage for each pair :)

It would be possible to set defaults for way more activity types but since garmin doesn't provide a website for undoing it i decided not to expose it here for the moment.
![image](https://user-images.githubusercontent.com/6293002/206023008-1778732d-880b-4bf0-8bc3-50a700db71e7.png)
