### PR TITLE
Add service for body composition

### DIFF
--- a/custom_components/garmin_connect/__init__.py
+++ b/custom_components/garmin_connect/__init__.py
@@ -207,3 +207,27 @@ class GarminConnectDataUpdateCoordinator(DataUpdateCoordinator):
             await self.hass.async_add_executor_job(
                 self._api.set_gear_default, activity_type_id, entity.uuid, True
             )
+
+    async def add_body_composition(self, entity, service_data):
+        """Record a weigh in/body composition"""
+        if not await self.async_login():
+            raise IntegrationError(
+                "Failed to login to Garmin Connect, unable to update"
+            )
+
+        await self.hass.async_add_executor_job(
+            self._api.add_body_composition,
+                    service_data.data.get("timestamp", None),
+                    service_data.data.get("weight"),
+                    service_data.data.get("percent_fat", None),
+                    service_data.data.get("percent_hydration", None),
+                    service_data.data.get("visceral_fat_mass", None),
+                    service_data.data.get("bone_mass", None),
+                    service_data.data.get("muscle_mass", None),
+                    service_data.data.get("basal_met", None),
+                    service_data.data.get("active_met", None),
+                    service_data.data.get("physique_rating", None),
+                    service_data.data.get("metabolic_age", None),
+                    service_data.data.get("visceral_fat_rating", None),
+                    service_data.data.get("bmi", None)
+        )

--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -101,6 +101,9 @@ async def async_setup_entry(
         "set_active_gear", ENTITY_SERVICE_SCHEMA, coordinator.set_active_gear
     )
 
+    platform.async_register_entity_service(
+        "add_body_composition", BODY_COMPOSITION_SERVICE_SCHEMA, coordinator.add_body_composition
+    )
 
 ENTITY_SERVICE_SCHEMA = vol.Schema(
     {
@@ -110,6 +113,24 @@ ENTITY_SERVICE_SCHEMA = vol.Schema(
     }
 )
 
+BODY_COMPOSITION_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): str,
+        vol.Optional("timestamp"): str,
+        vol.Required("weight"): float,
+        vol.Optional("percent_fat"): float,
+        vol.Optional("percent_hydration"): float,
+        vol.Optional("visceral_fat_mass"): float,
+        vol.Optional("bone_mass"): float,
+        vol.Optional("muscle_mass"): float,
+        vol.Optional("basal_met"): float,
+        vol.Optional("active_met"): float,
+        vol.Optional("physique_rating"): float,
+        vol.Optional("metabolic_age"): float,
+        vol.Optional("visceral_fat_rating"): float,
+        vol.Optional("bmi"): float
+    }
+)
 
 class GarminConnectSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Garmin Connect Sensor."""

--- a/custom_components/garmin_connect/services.yaml
+++ b/custom_components/garmin_connect/services.yaml
@@ -37,3 +37,79 @@ set_active_gear:
         entity:
           integration: garmin_connect
           device_class: garmin_gear
+
+add_body_composition:
+  name: Adds updated body composition metrics
+  fields:
+    weight:
+      required: true
+      name: Weight
+      description: Weight in KG
+      example: 82.3
+    timestamp:
+      required: false
+      name: Timestamp
+      description: Datetime string of when the measurements were recorded. Defaults to now.
+      example: 2023-12-30T07:34:00
+    bmi:
+      required: false
+      name: BMI (Body Mass Index)
+      description: Body mass index is based on weight and height.
+      example: 24.7
+    percent_fat:
+      required: false
+      name: Percent Fat
+      description: Percent body fat
+      example: 23.6
+    percent_hydration:
+      required: false
+      name: Percent Hydration
+      description: Percent body hydration
+      example: 51.2
+    visceral_fat_mass:
+      required: false
+      name: Visceral Fat Mass
+      description: Estimated mass of visceral fat in KG
+      example: 45.3
+    bone_mass:
+      required: false
+      name: Bone Mass
+      description: Estimated mass of bones in KG
+      example: 10.1
+    muscle_mass:
+      required: false
+      name: Muscle Mass
+      description: Estimated mass of muscle in KG
+      example: 15.2
+    basal_met:
+      required: false
+      name: Basel Metabolism
+      description: Basel metabolism
+      example: 1900
+    active_met:
+      required: false
+      name: Active Metabolism
+      description: Active metabolism
+      example: 840
+    physique_rating:
+      required: false
+      name: Physique Rating
+      description: Physique Rating
+      example: 28
+    metabolic_age:
+      required: false
+      name: Metabolic Age
+      description: Metabolic Age
+      example: 37
+    visceral_fat_rating:
+      required: false
+      name: Visceral Fat Rating
+      description: Visceral Fat Rating
+      example: 10
+    entity_id:
+      description: entity
+      required: true
+      selector:
+        entity:
+          integration: garmin_connect
+          device_class: weight


### PR DESCRIPTION
Related to https://github.com/cyberjunky/home-assistant-garmin_connect/issues/74, this adds a service for recording a weigh in/body composition using the `add_body_composition` method from python-garminconnect.

I'm running with this patch on my instance and it seems to work okay, though I haven't worked on a component before, so it's not impossible that this solution isn't ideal.

I don't have a lot of bandwidth to keep working on this, so if it needs edits it may take me a while to circle back. Alternately someone else is welcome to take this over the finish line 😅 