### PR TITLE
Bump garminconnect version

### DIFF
--- a/custom_components/garmin_connect/manifest.json
+++ b/custom_components/garmin_connect/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/cyberjunky/home-assistant-garmin_connect",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cyberjunky/home-assistant-garmin_connect/issues",
-  "requirements": ["garminconnect==0.2.12", "tzlocal"],
+  "requirements": ["garminconnect>=0.2.15", "tzlocal"],
   "version": "0.2.19"
 }


### PR DESCRIPTION
Pinning to a specific version seems a bit restrictive- especially since you seem to update garminconnect more often

Thanks for the project!