### PR TITLE
Add total sleep duration sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Sedentary Time
 Sleeping Time
 Awake Duration
 Sleep Duration
+Total Sleep Duration
 Floors Ascended
 Floors Descended
 Floors Ascended Goal

--- a/custom_components/garmin_connect/__init__.py
+++ b/custom_components/garmin_connect/__init__.py
@@ -111,6 +111,7 @@ class GarminConnectDataUpdateCoordinator(DataUpdateCoordinator):
         activity_types = {}
         sleep_data = {}
         sleep_score = None
+        sleep_time_seconds = None
         hrv_data = {}
         hrvStatus = {"status": "UNKNOWN"}
 
@@ -191,6 +192,12 @@ class GarminConnectDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Sleep score data is not available")
 
         try:
+            sleep_time_seconds = sleep_data["dailySleepDTO"]["sleepTimeSeconds"]
+            _LOGGER.debug(f"Sleep time seconds data: {sleep_time_seconds}")
+        except KeyError:
+            _LOGGER.debug("Sleep time seconds data is not available")
+
+        try:
             if hrv_data and "hrvSummary" in hrv_data:
                 hrvStatus = hrv_data["hrvSummary"]
                 _LOGGER.debug(f"HRV status: {hrvStatus} ")
@@ -206,6 +213,7 @@ class GarminConnectDataUpdateCoordinator(DataUpdateCoordinator):
             "activity_types": activity_types,
             "gear_defaults": gear_defaults,
             "sleepScore": sleep_score,
+            "sleepTimeSeconds": sleep_time_seconds,
             "hrvStatus": hrvStatus,
         }
 

--- a/custom_components/garmin_connect/const.py
+++ b/custom_components/garmin_connect/const.py
@@ -409,6 +409,7 @@ GARMIN_ENTITY_LIST = {
         SensorStateClass.MEASUREMENT,
         True,
     ],
+    "sleepTimeSeconds": ["Total Sleep Duration", UnitOfTime.MINUTES, "mdi:sleep", None, SensorStateClass.TOTAL, True],
     "hrvStatus": [
         "HRV Status",
         None,


### PR DESCRIPTION
As observed in #75 and #163, the sleep duration sensor is not the same as the sleep duration shown on the Garmin Connect Portal. The sleep duration sensor is retrieved from the `get_user_summary` method of the garminconnect Python library. My implementation of the *total* sleep duration sensor uses the `get_sleep_data` method and takes the `sleepTimeSeconds`, similar to the sleep score sensor.

Example:

Sleep duration from Garmin Connect Portal:

![Screenshot from 2025-01-07 20-04-11](https://github.com/user-attachments/assets/56528a20-d0c0-48f9-975a-d4206a61f4ed)

Sleep Duration from total sleep duration sensor (458min = 7h 38min):

![Screenshot from 2025-01-07 20-08-52](https://github.com/user-attachments/assets/7125b36f-7293-4963-a0d8-d7dcd547a969)
