### PR TITLE
Add hydration intake logging service

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ data:
 
 #### Add Hydration
 
-```
+```yaml
 action: garmin_connect.add_hydration
 data:
   entity_id: sensor.hydration

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ data:
   notes: Measured with Beurer BC54
 ```
 
+#### Add Hydration
+
+```
+action: garmin_connect.add_hydration
+data:
+  entity_id: sensor.hydration
+  value_in_ml: 250
+```
+
 ## Debugging
 
 Add the relevant lines below to the `configuration.yaml`:

--- a/custom_components/garmin_connect/const.py
+++ b/custom_components/garmin_connect/const.py
@@ -713,7 +713,7 @@ GARMIN_ENTITY_LIST = {
         SensorStateClass.MEASUREMENT,
         True,
     ],
-    "dailyAverageInML": [
+    "dailyAverageinML": [
         "Hydration Daily Average",
         UnitOfVolume.MILLILITERS,
         "mdi:water",

--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -158,6 +158,16 @@ async def async_setup_entry(
         "add_blood_pressure",
     )
 
+    platform.async_register_entity_service(
+        "add_hydration",
+        {
+            vol.Required(ATTR_ENTITY_ID): str,
+            vol.Required("value_in_ml"): vol.Coerce(float),
+            vol.Optional("timestamp"): str,
+        },
+        "add_hydration",
+    )
+
 
 class GarminConnectSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Garmin Connect Sensor."""
@@ -392,6 +402,30 @@ class GarminConnectSensor(CoordinatorEntity, SensorEntity):
             pulse,
             timestamp,
             notes,
+        )
+
+    async def add_hydration(self, **kwargs):
+        """Add a hydration intake record to Garmin Connect.
+
+        Parameters:
+            value_in_ml: Amount of liquid in millilitres (positive to add, negative to subtract).
+            timestamp: Optional timestamp in YYYY-MM-DDThh:mm:ss.ms format.
+
+        Raises:
+            IntegrationError: If unable to log in to Garmin Connect.
+        """
+        value_in_ml = kwargs.get("value_in_ml")
+        timestamp = kwargs.get("timestamp")
+
+        if not await self.coordinator.async_login():
+            raise IntegrationError(
+                "Failed to login to Garmin Connect, unable to update"
+            )
+
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.add_hydration_data,
+            value_in_ml,
+            timestamp,
         )
 
 

--- a/custom_components/garmin_connect/services.yaml
+++ b/custom_components/garmin_connect/services.yaml
@@ -152,3 +152,25 @@ add_blood_pressure:
       name: Notes
       description: Add notes to the measurement
       example: 'Measured with Beurer BC54'
+
+add_hydration:
+  name: Log hydration intake
+  description: Log a hydration intake record to Garmin Connect.
+  fields:
+    entity_id:
+      name: entity
+      description: entity
+      required: true
+      selector:
+        entity:
+          integration: garmin_connect
+    value_in_ml:
+      required: true
+      name: Value in mL
+      description: Amount of liquid in millilitres. Use a positive value to add intake, negative to subtract.
+      example: 250.0
+    timestamp:
+      required: false
+      name: Timestamp
+      description: Datetime string of when the intake was recorded. Defaults to now.
+      example: 2025-01-15T08:30:00.000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for Garmin Connect integration tests."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock Garmin Connect API client."""
+    api = MagicMock()
+    api.add_hydration_data = MagicMock()
+    api.add_body_composition = MagicMock()
+    api.set_blood_pressure = MagicMock()
+    return api
+
+
+@pytest.fixture
+def mock_coordinator(mock_api):
+    """Create a mock coordinator with a working API and login."""
+    coordinator = MagicMock()
+    coordinator.api = mock_api
+    coordinator.async_login = AsyncMock(return_value=True)
+    coordinator.data = {
+        "valueInML": 1500.0,
+        "goalInML": 2500.0,
+        "lastSyncTimestampGMT": "2026-03-15T12:00:00.0",
+    }
+    return coordinator
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock()
+
+    async def async_add_executor_job(func, *args):
+        return func(*args)
+
+    hass.async_add_executor_job = async_add_executor_job
+    return hass

--- a/tests/test_add_hydration.py
+++ b/tests/test_add_hydration.py
@@ -1,0 +1,53 @@
+"""Tests for the add_hydration entity service."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.exceptions import IntegrationError
+
+
+@pytest.fixture
+def hydration_sensor(mock_coordinator, mock_hass):
+    """Create a GarminConnectSensor instance for hydration testing."""
+    from custom_components.garmin_connect.sensor import GarminConnectSensor
+
+    sensor = GarminConnectSensor.__new__(GarminConnectSensor)
+    sensor.coordinator = mock_coordinator
+    sensor.hass = mock_hass
+    return sensor
+
+
+class TestAddHydration:
+    """Tests for the add_hydration service method."""
+
+    async def test_add_hydration_required_params_only(self, hydration_sensor, mock_api):
+        """Logging hydration with only value_in_ml calls the API correctly."""
+        await hydration_sensor.add_hydration(value_in_ml=250.0)
+
+        mock_api.add_hydration_data.assert_called_once_with(250.0, None)
+
+    async def test_add_hydration_with_timestamp(self, hydration_sensor, mock_api):
+        """Logging hydration with a timestamp passes it through to the API."""
+        await hydration_sensor.add_hydration(
+            value_in_ml=500.0,
+            timestamp="2026-03-15T08:30:00.000",
+        )
+
+        mock_api.add_hydration_data.assert_called_once_with(
+            500.0, "2026-03-15T08:30:00.000"
+        )
+
+    async def test_add_hydration_login_failure_raises(self, hydration_sensor, mock_coordinator):
+        """When login fails, add_hydration raises IntegrationError."""
+        mock_coordinator.async_login = AsyncMock(return_value=False)
+
+        with pytest.raises(IntegrationError, match="Failed to login"):
+            await hydration_sensor.add_hydration(value_in_ml=250.0)
+
+        mock_coordinator.api.add_hydration_data.assert_not_called()
+
+    async def test_add_hydration_negative_value(self, hydration_sensor, mock_api):
+        """Negative values (subtracting intake) are passed through to the API."""
+        await hydration_sensor.add_hydration(value_in_ml=-100.0)
+
+        mock_api.add_hydration_data.assert_called_once_with(-100.0, None)


### PR DESCRIPTION
## Summary

- Adds an `add_hydration` entity service to log water intake to Garmin Connect
- Fixes a casing bug in the existing Hydration Daily Average sensor (`dailyAverageinML`)
- Includes unit tests and documentation

## Details

The `garminconnect` library already provides `add_hydration_data()` but it was not exposed as a Home Assistant service. This PR wires it up following the same pattern as the existing `add_body_composition` and `add_blood_pressure` services.

**New service: `garmin_connect.add_hydration`**
- `value_in_ml` (required, float) — millilitres to log (positive to add, negative to subtract)
- `timestamp` (optional, string) — when the intake was recorded, defaults to now

**Bug fix (separate commit):** The Garmin API returns `dailyAverageinML` (lowercase "i") but the sensor key used `dailyAverageInML` (uppercase "I"), so the Hydration Daily Average sensor never received data.

## Implementation notes

- No additional API calls introduced — uses the existing `garminconnect` library method
- Service registration, method implementation, and error handling follow the exact pattern of `add_body_composition` and `add_blood_pressure`
- The `entity_id` selector in `services.yaml` does not include a `device_class` filter because the hydration sensors have `device_class: None`. This is consistent with the existing `add_blood_pressure` and `set_active_gear` services, which filter by device classes that do not match any sensor either (`min_heart_rate` and `garmin_gear` respectively). This appears to be a pre-existing issue across the integration that could be addressed separately.

## Tests

This repo does not currently have tests or a test CI workflow. I have included unit tests (4 tests covering required params, optional timestamp, login failure, and negative values) with shared pytest fixtures. These are fully self-contained in `tests/` and have no impact on the integration code. They can be removed if the maintainer prefers not to maintain them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hydration logging service to record liquid intake with required value and optional timestamp.

* **Bug Fixes**
  * Corrected a mapping key typo to ensure consistent sensor behavior.

* **Documentation**
  * Added an "Add Hydration" example with a YAML snippet demonstrating usage.

* **Tests**
  * Added unit tests and shared fixtures covering normal, timestamped, failure, and negative-value scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->