### PR TITLE
Move Garmin() constructor calls to executor

### DIFF
--- a/custom_components/garmin_connect/__init__.py
+++ b/custom_components/garmin_connect/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Awaitable
 from datetime import datetime, timedelta
+from functools import partial
 import logging
 from zoneinfo import ZoneInfo
 import requests
@@ -56,7 +57,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             in_china = hass.config.country == "CN"
 
             # Create temporary API client to get token
-            api = Garmin(email=username, password=password, is_cn=in_china)
+            api = await hass.async_add_executor_job(
+                partial(Garmin, email=username, password=password, is_cn=in_china)
+            )
 
             try:
                 # Login to get the token
@@ -136,6 +139,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Garmin Connect from a config entry."""
 
     coordinator = GarminConnectDataUpdateCoordinator(hass, entry=entry)
+    await coordinator._async_init_api()
 
     if not await coordinator.async_login():
         return False
@@ -180,10 +184,16 @@ class GarminConnectDataUpdateCoordinator(DataUpdateCoordinator):
         self.time_zone = self.hass.config.time_zone
         _LOGGER.debug("Time zone: %s", self.time_zone)
 
-        self.api = Garmin(is_cn=self._in_china)
+        self.api = None
 
         super().__init__(hass, _LOGGER, name=DOMAIN,
                          update_interval=DEFAULT_UPDATE_INTERVAL)
+
+    async def _async_init_api(self) -> None:
+        """Initialize the Garmin API client off the event loop."""
+        self.api = await self.hass.async_add_executor_job(
+            partial(Garmin, is_cn=self._in_china)
+        )
 
     async def async_login(self) -> bool:
         """

--- a/custom_components/garmin_connect/config_flow.py
+++ b/custom_components/garmin_connect/config_flow.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Mapping
+from functools import partial
 from typing import Any, cast
 import requests
 from garminconnect import (
@@ -66,8 +67,10 @@ class GarminConnectConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         if country == "CN":
             self._in_china = True
 
-        self._api = Garmin(email=self._username,
-                           password=self._password, return_on_mfa=True, is_cn=self._in_china)
+        self._api = await self.hass.async_add_executor_job(
+            partial(Garmin, email=self._username,
+                    password=self._password, return_on_mfa=True, is_cn=self._in_china)
+        )
 
         try:
             self._login_result1, self._login_result2 = await self.hass.async_add_executor_job(self._api.login)


### PR DESCRIPTION
The `Garmin()` constructor does blocking I/O under the hood — `listdir` on site-packages, reading `entry_points.txt`, importing modules. HA 2026.3 now catches this and logs warnings when it happens on the event loop.

Three call sites were affected:
- `__init__.py:183` — coordinator `__init__`, moved to a new `_async_init_api()` method
- `__init__.py:60` — migration path
- `config_flow.py:69` — config flow setup

All three now use `async_add_executor_job(partial(Garmin, ...))`.

Fixes #425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the Garmin API initialization process to improve responsiveness during setup and login operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->