### PR TITLE
fix: use gear UUID instead of name for unique_id

### DIFF
--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -1576,8 +1576,7 @@ class GarminConnectGearSensor(CoordinatorEntity[GearCoordinator], SensorEntity):
         self._attr_device_class = SensorDeviceClass.DISTANCE
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self._attr_suggested_display_precision = 0
-        clean_name = self._gear_name.lower().replace(" ", "_").replace("-", "_")
-        self._attr_unique_id = f"{entry_id}_gear_{clean_name}"
+        self._attr_unique_id = f"{entry_id}_gear_{gear_uuid}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},
             name="Garmin Connect",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -462,10 +462,10 @@ def test_gear_sensor_name_property() -> None:
 
 
 def test_gear_sensor_unique_id() -> None:
-    """Gear sensor unique_id must be '{entry_id}_gear_{cleaned_name}'."""
+    """Gear sensor unique_id must be '{entry_id}_gear_{gear_uuid}'."""
     coord = MagicMock()
     coord.data = {}
     sensor = GarminConnectGearSensor(
-        coord, gear_uuid="uuid", gear_name="My Trail Shoes", entry_id="my_entry"
+        coord, gear_uuid="abc-123", gear_name="My Trail Shoes", entry_id="my_entry"
     )
-    assert sensor._attr_unique_id == "my_entry_gear_my_trail_shoes"
+    assert sensor._attr_unique_id == "my_entry_gear_abc-123"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -469,3 +469,18 @@ def test_gear_sensor_unique_id() -> None:
         coord, gear_uuid="abc-123", gear_name="My Trail Shoes", entry_id="my_entry"
     )
     assert sensor._attr_unique_id == "my_entry_gear_abc-123"
+
+
+def test_gear_sensor_unique_id_unnamed_gear_no_collision() -> None:
+    """Two unnamed gear items with different UUIDs must have distinct unique_ids."""
+    coord = MagicMock()
+    coord.data = {}
+    sensor_a = GarminConnectGearSensor(
+        coord, gear_uuid="abc-123", gear_name=None, entry_id="my_entry"
+    )
+    sensor_b = GarminConnectGearSensor(
+        coord, gear_uuid="def-456", gear_name=None, entry_id="my_entry"
+    )
+    assert sensor_a._attr_unique_id == "my_entry_gear_abc-123"
+    assert sensor_b._attr_unique_id == "my_entry_gear_def-456"
+    assert sensor_a._attr_unique_id != sensor_b._attr_unique_id


### PR DESCRIPTION
## Summary

- Gear sensors derive `unique_id` from gear name, which falls back to `"Unknown"` when no nickname is set
- Multiple unnamed gear items all get `{entry_id}_gear_unknown` → HA drops all duplicates silently
- Fix: use `gear_uuid` (already available and guaranteed unique) instead of sanitized name

Regression from the #443 NoneType fix. One-line change, tested locally — all gear sensors now created correctly.

Fixes #461

## Test plan

- [x] Verified locally: 7 duplicate `gear_unknown` errors before → 0 after
- [x] Gear sensors with names still work (uuid is always used, name is still shown via `self.name`)
- [x] Python syntax validated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gear sensor entity IDs now use stable internal IDs instead of deriving from gear display names. This improves identifier stability but may change existing gear sensor IDs—please update any automations, dashboards, or configurations that reference those sensor IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->