### PR TITLE
Fix VO2 Max value_fn crash when generic is null

### DIFF
--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -914,8 +914,8 @@ TRAINING_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="mL/(kg·min)",
         value_fn=lambda data: data.get("vo2MaxValue") or (
-            ((data.get("trainingStatus") or {}).get("mostRecentVO2Max") or {})
-            .get("generic", {})
+            (((data.get("trainingStatus") or {}).get("mostRecentVO2Max") or {})
+             .get("generic") or {})
             .get("vo2MaxValue")
         ),
     ),


### PR DESCRIPTION
## Summary

The VO2 Max sensor's `value_fn` raises `AttributeError: 'NoneType' object has no attribute 'get'` for accounts without a VO2-capable watch (e.g. users with only a smart scale or BP monitor on their Garmin account).

Because the exception fires inside the coordinator's `async_update_listeners` broadcast loop — which iterates listeners without a try/except — **every sensor registered after VO2 Max in the listener list stays at `unknown` on every refresh**. The integration looks completely broken despite the coordinator successfully fetching data.

## Root cause

`sensor.py:918` uses `.get("generic", {})`. The default parameter of `dict.get(key, default)` is only returned when the key is **missing**. If the key exists with value `None`, `.get` returns `None`, and the chained `.get("vo2MaxValue")` crashes.

Garmin's `/wellness-service/.../trainingStatus` response includes `mostRecentVO2Max.generic: null` for accounts without VO2 data (no VO2-capable watch synced). The key is present; the value is `null`. The default doesn't save us.

```python
>>> {"generic": None}.get("generic", {})
# returns None, not {}
```

Every other intermediate dict in this same lambda uses `(... or {})` and handles this correctly — the `.get("generic", {})` spot was the one inconsistency.

## Fix

Replace the default parameter with an `or {}` coalesce so both missing-key and `None`-value fall back to an empty dict:

```diff
-            ((data.get("trainingStatus") or {}).get("mostRecentVO2Max") or {})
-            .get("generic", {})
+            (((data.get("trainingStatus") or {}).get("mostRecentVO2Max") or {})
+             .get("generic") or {})
             .get("vo2MaxValue")
```

Two-char change; no behavioural difference when `generic` is a populated dict.

## Observed symptom

- 96 Garmin sensors all stuck at `unknown` state after HA startup.
- HA reports integration state as `loaded`, no auth errors.
- System log shows a single repeating error at `sensor.py:919`:

```
AttributeError: 'NoneType' object has no attribute 'get'
  File "custom_components/garmin_connect/sensor.py", line 919, in <lambda>
      .get("vo2MaxValue")
```

- After the patch: VO2 Max reports `None` (correct — no data for this account), and every other sensor (weight, BP, cycling, hydration, etc.) populates with real values.

## Test plan

- [x] Patch applied to a live HA instance with an affected Garmin account (scale + BP monitor only, no watch). After HA restart, all non-watch sensors populated with real values; VO2 Max correctly reports `unknown` with no exception.
- [ ] Verify against an account that **does** have VO2 Max data — `data.get("vo2MaxValue")` path still short-circuits first, and `generic` being a populated dict passes through unchanged.

Any account with VO2 data should be unaffected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced VO2 Max sensor data retrieval to ensure proper fallback handling when data values are missing or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->