### PR TITLE
fix: restore entity_id support for add_body_composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Record body composition metrics to Garmin Connect.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
+| `entity_id` | No | Garmin Connect entity whose account should receive the measurement |
 | `weight` | Yes | Weight in kg |
 | `timestamp` | No | ISO datetime (defaults to now) |
 | `bmi` | No | Body Mass Index |
@@ -369,6 +370,7 @@ Record body composition metrics to Garmin Connect.
 ```yaml
 action: garmin_connect.add_body_composition
 data:
+  entity_id: sensor.garmin_connect_weight
   weight: 82.3
   percent_fat: 23.6
   muscle_mass: 35.5

--- a/custom_components/garmin_connect/services.py
+++ b/custom_components/garmin_connect/services.py
@@ -151,7 +151,8 @@ def _get_client(
         if entry is None:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="integration_not_loaded",
+                translation_key="entity_not_found",
+                translation_placeholders={"entity_id": entity_id},
             )
 
     if getattr(entry, "runtime_data", None) is None:

--- a/custom_components/garmin_connect/services.py
+++ b/custom_components/garmin_connect/services.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -11,6 +10,7 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN
 
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
     from ha_garmin import GarminClient
 
     from .coordinator import GarminConnectCoordinators
-
-_LOGGER = logging.getLogger(__name__)
 
 # Service names
 SERVICE_SET_ACTIVE_GEAR = "set_active_gear"
@@ -46,6 +44,7 @@ SET_ACTIVE_GEAR_SCHEMA = vol.Schema(
 
 ADD_BODY_COMPOSITION_SCHEMA = vol.Schema(
     {
+        vol.Optional("entity_id"): cv.entity_id,
         vol.Required("weight"): vol.Coerce(float),
         vol.Optional("timestamp"): cv.string,
         vol.Optional("bmi"): vol.Coerce(float),
@@ -117,8 +116,12 @@ ADD_HYDRATION_SCHEMA = vol.Schema(
 )
 
 
-def _get_client(hass: HomeAssistant) -> GarminClient:
-    """Get the Garmin client from the first available config entry."""
+def _get_client(
+    hass: HomeAssistant,
+    *,
+    entity_id: str | None = None,
+) -> GarminClient:
+    """Get the Garmin client for a targeted or fallback config entry."""
     entries = hass.config_entries.async_entries(DOMAIN)
     if not entries:
         raise HomeAssistantError(
@@ -127,7 +130,31 @@ def _get_client(hass: HomeAssistant) -> GarminClient:
         )
 
     entry = entries[0]
-    if not hasattr(entry, "runtime_data") or entry.runtime_data is None:
+
+    if entity_id:
+        registry_entry = er.async_get(hass).async_get(entity_id)
+        if registry_entry is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="entity_not_found",
+                translation_placeholders={"entity_id": entity_id},
+            )
+
+        entry = next(
+            (
+                candidate
+                for candidate in entries
+                if candidate.entry_id == registry_entry.config_entry_id
+            ),
+            None,
+        )
+        if entry is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="integration_not_loaded",
+            )
+
+    if getattr(entry, "runtime_data", None) is None:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="integration_not_loaded",
@@ -142,13 +169,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
     async def handle_set_active_gear(call: ServiceCall) -> None:
         """Handle set_active_gear service call."""
-        client = _get_client(hass)
         activity_type = call.data["activity_type"]
         setting = call.data["setting"]
         gear_uuid = call.data.get("gear_uuid")
+        entity_id = call.data.get("entity_id")
 
         if not gear_uuid:
-            entity_id = call.data.get("entity_id")
             if not entity_id:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
@@ -169,6 +195,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     translation_placeholders={"entity_id": entity_id},
                 )
 
+        client = _get_client(hass, entity_id=entity_id)
         try:
             await client.set_active_gear(
                 activity_type=activity_type,
@@ -184,7 +211,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
     async def handle_add_body_composition(call: ServiceCall) -> None:
         """Handle add_body_composition service call."""
-        client = _get_client(hass)
+        client = _get_client(
+            hass,
+            entity_id=call.data.get("entity_id"),
+        )
         try:
             await client.add_body_composition(
                 timestamp=call.data.get("timestamp"),
@@ -275,12 +305,11 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
     async def handle_add_gear_to_activity(call: ServiceCall) -> None:
         """Handle add_gear_to_activity service call."""
-        client = _get_client(hass)
         activity_id = call.data["activity_id"]
         gear_uuid = call.data.get("gear_uuid")
+        entity_id = call.data.get("entity_id")
 
         if not gear_uuid:
-            entity_id = call.data.get("entity_id")
             if not entity_id:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
@@ -301,6 +330,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     translation_placeholders={"entity_id": entity_id},
                 )
 
+        client = _get_client(hass, entity_id=entity_id)
         try:
             await client.add_gear_to_activity(
                 gear_uuid=gear_uuid,
@@ -329,25 +359,46 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             ) from err
 
     hass.services.async_register(
-        DOMAIN, SERVICE_SET_ACTIVE_GEAR, handle_set_active_gear, schema=SET_ACTIVE_GEAR_SCHEMA
+        DOMAIN,
+        SERVICE_SET_ACTIVE_GEAR,
+        handle_set_active_gear,
+        schema=SET_ACTIVE_GEAR_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_ADD_BODY_COMPOSITION, handle_add_body_composition, schema=ADD_BODY_COMPOSITION_SCHEMA
+        DOMAIN,
+        SERVICE_ADD_BODY_COMPOSITION,
+        handle_add_body_composition,
+        schema=ADD_BODY_COMPOSITION_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_ADD_BLOOD_PRESSURE, handle_add_blood_pressure, schema=ADD_BLOOD_PRESSURE_SCHEMA
+        DOMAIN,
+        SERVICE_ADD_BLOOD_PRESSURE,
+        handle_add_blood_pressure,
+        schema=ADD_BLOOD_PRESSURE_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_CREATE_ACTIVITY, handle_create_activity, schema=CREATE_ACTIVITY_SCHEMA
+        DOMAIN,
+        SERVICE_CREATE_ACTIVITY,
+        handle_create_activity,
+        schema=CREATE_ACTIVITY_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_UPLOAD_ACTIVITY, handle_upload_activity, schema=UPLOAD_ACTIVITY_SCHEMA
+        DOMAIN,
+        SERVICE_UPLOAD_ACTIVITY,
+        handle_upload_activity,
+        schema=UPLOAD_ACTIVITY_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_ADD_GEAR_TO_ACTIVITY, handle_add_gear_to_activity, schema=ADD_GEAR_TO_ACTIVITY_SCHEMA
+        DOMAIN,
+        SERVICE_ADD_GEAR_TO_ACTIVITY,
+        handle_add_gear_to_activity,
+        schema=ADD_GEAR_TO_ACTIVITY_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_ADD_HYDRATION, handle_add_hydration, schema=ADD_HYDRATION_SCHEMA
+        DOMAIN,
+        SERVICE_ADD_HYDRATION,
+        handle_add_hydration,
+        schema=ADD_HYDRATION_SCHEMA,
     )
 
 

--- a/custom_components/garmin_connect/services.yaml
+++ b/custom_components/garmin_connect/services.yaml
@@ -41,148 +41,71 @@ add_body_composition:
   name: Add body composition
   description: Upload a body composition measurement to Garmin Connect.
   fields:
+    entity_id:
+      name: Garmin Connect entity
+      description: Optional Garmin Connect entity whose account should receive the measurement.
+      selector:
+        entity:
+          integration: garmin_connect
     weight:
       name: Weight (kg)
       description: Body weight in kilograms.
       required: true
       selector:
         number:
-          min: 20
+          min: 0
           max: 300
           step: 0.1
           unit_of_measurement: kg
     timestamp:
       name: Timestamp
-      description: "Measurement time (ISO 8601, e.g. 2024-01-15T08:30:00). Defaults to now."
-      example: "2024-01-15T08:30:00"
+      description: When the measurement was recorded (defaults to now).
       selector:
         text:
     bmi:
       name: BMI
       selector:
         number:
-          min: 10
-          max: 60
-          step: 0.1
     percent_fat:
-      name: Body fat (%)
+      name: Body fat percentage
       selector:
         number:
-          min: 1
-          max: 70
-          step: 0.1
-          unit_of_measurement: "%"
     percent_hydration:
-      name: Body hydration (%)
+      name: Hydration percentage
       selector:
         number:
-          min: 1
-          max: 80
-          step: 0.1
-          unit_of_measurement: "%"
     visceral_fat_mass:
-      name: Visceral fat mass (kg)
+      name: Visceral fat mass
       selector:
         number:
-          min: 0
-          max: 50
-          step: 0.1
-          unit_of_measurement: kg
     bone_mass:
-      name: Bone mass (kg)
+      name: Bone mass
       selector:
         number:
-          min: 0
-          max: 10
-          step: 0.1
-          unit_of_measurement: kg
     muscle_mass:
-      name: Muscle mass (kg)
+      name: Muscle mass
       selector:
         number:
-          min: 0
-          max: 150
-          step: 0.1
-          unit_of_measurement: kg
     basal_met:
-      name: Basal metabolic rate (kcal)
+      name: Basal metabolism
       selector:
         number:
-          min: 500
-          max: 5000
-          step: 1
-          unit_of_measurement: kcal
     active_met:
-      name: Active metabolic rate (kcal)
+      name: Active metabolism
       selector:
         number:
-          min: 500
-          max: 10000
-          step: 1
-          unit_of_measurement: kcal
     physique_rating:
       name: Physique rating
       selector:
         number:
-          min: 1
-          max: 9
-          step: 1
     metabolic_age:
       name: Metabolic age
       selector:
         number:
-          min: 10
-          max: 100
-          step: 1
     visceral_fat_rating:
       name: Visceral fat rating
       selector:
         number:
-          min: 1
-          max: 59
-          step: 1
-
-add_blood_pressure:
-  name: Add blood pressure
-  description: Upload a blood pressure reading to Garmin Connect.
-  fields:
-    systolic:
-      name: Systolic (mmHg)
-      required: true
-      selector:
-        number:
-          min: 60
-          max: 250
-          step: 1
-          unit_of_measurement: mmHg
-    diastolic:
-      name: Diastolic (mmHg)
-      required: true
-      selector:
-        number:
-          min: 40
-          max: 150
-          step: 1
-          unit_of_measurement: mmHg
-    pulse:
-      name: Pulse (bpm)
-      required: true
-      selector:
-        number:
-          min: 30
-          max: 220
-          step: 1
-          unit_of_measurement: bpm
-    timestamp:
-      name: Timestamp
-      description: "Measurement time (ISO 8601). Defaults to now."
-      example: "2024-01-15T08:30:00"
-      selector:
-        text:
-    notes:
-      name: Notes
-      selector:
-        text:
 
 create_activity:
   name: Create activity

--- a/custom_components/garmin_connect/services.yaml
+++ b/custom_components/garmin_connect/services.yaml
@@ -53,59 +53,142 @@ add_body_composition:
       required: true
       selector:
         number:
-          min: 0
+          min: 20
           max: 300
           step: 0.1
           unit_of_measurement: kg
     timestamp:
       name: Timestamp
-      description: When the measurement was recorded (defaults to now).
+      description: "Measurement time (ISO 8601, e.g. 2024-01-15T08:30:00). Defaults to now."
+      example: "2024-01-15T08:30:00"
       selector:
         text:
     bmi:
       name: BMI
       selector:
         number:
+          min: 10
+          max: 60
+          step: 0.1
     percent_fat:
-      name: Body fat percentage
+      name: Body fat (%)
       selector:
         number:
+          min: 1
+          max: 70
+          step: 0.1
+          unit_of_measurement: "%"
     percent_hydration:
-      name: Hydration percentage
+      name: Body hydration (%)
       selector:
         number:
+          min: 1
+          max: 80
+          step: 0.1
+          unit_of_measurement: "%"
     visceral_fat_mass:
-      name: Visceral fat mass
+      name: Visceral fat mass (kg)
       selector:
         number:
+          min: 0
+          max: 50
+          step: 0.1
+          unit_of_measurement: kg
     bone_mass:
-      name: Bone mass
+      name: Bone mass (kg)
       selector:
         number:
+          min: 0
+          max: 10
+          step: 0.1
+          unit_of_measurement: kg
     muscle_mass:
-      name: Muscle mass
+      name: Muscle mass (kg)
       selector:
         number:
+          min: 0
+          max: 150
+          step: 0.1
+          unit_of_measurement: kg
     basal_met:
-      name: Basal metabolism
+      name: Basal metabolic rate (kcal)
       selector:
         number:
+          min: 500
+          max: 5000
+          step: 1
+          unit_of_measurement: kcal
     active_met:
-      name: Active metabolism
+      name: Active metabolic rate (kcal)
       selector:
         number:
+          min: 500
+          max: 10000
+          step: 1
+          unit_of_measurement: kcal
     physique_rating:
       name: Physique rating
       selector:
         number:
+          min: 1
+          max: 9
+          step: 1
     metabolic_age:
       name: Metabolic age
       selector:
         number:
+          min: 10
+          max: 100
+          step: 1
     visceral_fat_rating:
       name: Visceral fat rating
       selector:
         number:
+          min: 1
+          max: 59
+          step: 1
+
+add_blood_pressure:
+  name: Add blood pressure
+  description: Upload a blood pressure reading to Garmin Connect.
+  fields:
+    systolic:
+      name: Systolic (mmHg)
+      required: true
+      selector:
+        number:
+          min: 60
+          max: 250
+          step: 1
+          unit_of_measurement: mmHg
+    diastolic:
+      name: Diastolic (mmHg)
+      required: true
+      selector:
+        number:
+          min: 40
+          max: 150
+          step: 1
+          unit_of_measurement: mmHg
+    pulse:
+      name: Pulse (bpm)
+      required: true
+      selector:
+        number:
+          min: 30
+          max: 220
+          step: 1
+          unit_of_measurement: bpm
+    timestamp:
+      name: Timestamp
+      description: "Measurement time (ISO 8601). Defaults to now."
+      example: "2024-01-15T08:30:00"
+      selector:
+        text:
+    notes:
+      name: Notes
+      selector:
+        text:
 
 create_activity:
   name: Create activity

--- a/custom_components/garmin_connect/translations/en.json
+++ b/custom_components/garmin_connect/translations/en.json
@@ -241,6 +241,7 @@
       "name": "Add body composition",
       "description": "Add body composition metrics to Garmin Connect.",
       "fields": {
+        "entity_id": { "name": "Garmin Connect entity", "description": "Optional Garmin Connect entity whose account should receive the measurement." },
         "weight": { "name": "Weight", "description": "Weight in kilograms." },
         "timestamp": { "name": "Timestamp", "description": "When the measurement was recorded (defaults to now)." },
         "bmi": { "name": "BMI", "description": "Body Mass Index." },

--- a/docs/garmin_connect.markdown
+++ b/docs/garmin_connect.markdown
@@ -131,6 +131,7 @@ Add body composition metrics to Garmin Connect.
 
 | Data attribute | Required | Description |
 | ---------------------- | -------- | ----------- |
+| `entity_id` | No | Garmin Connect entity whose account should receive the measurement |
 | `weight` | Yes | Weight in kilograms |
 | `timestamp` | No | ISO format timestamp |
 | `bmi` | No | Body Mass Index |

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,7 +1,7 @@
 """Tests for Garmin Connect services."""
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
@@ -12,8 +12,6 @@ from custom_components.garmin_connect.services import (
     async_unload_services,
 )
 
-# ── Fixtures / helpers ────────────────────────────────────────────────────────
-
 
 @pytest.fixture
 def mock_hass() -> MagicMock:
@@ -21,15 +19,24 @@ def mock_hass() -> MagicMock:
     hass = MagicMock()
     hass.config.time_zone = "Europe/Amsterdam"
 
+    mock_entry = _make_entry("entry_1", "profile_1", "user1@example.com")
+
+    hass.config_entries.async_entries.return_value = [mock_entry]
+    return hass
+
+
+def _make_entry(entry_id: str, unique_id: str, title: str) -> MagicMock:
+    """Return a mock config entry with a Garmin client."""
     mock_client = AsyncMock()
     mock_coordinators = MagicMock()
     mock_coordinators.core.client = mock_client
 
     mock_entry = MagicMock()
+    mock_entry.entry_id = entry_id
+    mock_entry.unique_id = unique_id
+    mock_entry.title = title
     mock_entry.runtime_data = mock_coordinators
-
-    hass.config_entries.async_entries.return_value = [mock_entry]
-    return hass
+    return mock_entry
 
 
 def _get_handler(mock_hass: MagicMock, service_name: str):
@@ -46,7 +53,12 @@ def _get_client(mock_hass: MagicMock) -> AsyncMock:
     return entry.runtime_data.core.client
 
 
-# ── Registration / unregistration ─────────────────────────────────────────────
+def _get_client_for_entry(mock_hass: MagicMock, entry_id: str) -> AsyncMock:
+    """Get the mock client for a specific mock config entry."""
+    for entry in mock_hass.config_entries.async_entries.return_value:
+        if entry.entry_id == entry_id:
+            return entry.runtime_data.core.client
+    raise ValueError(f"Entry {entry_id} not configured")
 
 
 async def test_setup_registers_all_services(mock_hass: MagicMock) -> None:
@@ -85,9 +97,6 @@ async def test_unload_removes_all_services(mock_hass: MagicMock) -> None:
     }
 
 
-# ── _get_client error paths ───────────────────────────────────────────────────
-
-
 async def test_service_no_entry_raises(mock_hass: MagicMock) -> None:
     """Services must raise HomeAssistantError when no config entry exists."""
     mock_hass.config_entries.async_entries.return_value = []
@@ -116,9 +125,6 @@ async def test_service_entry_not_loaded_raises(mock_hass: MagicMock) -> None:
 
     with pytest.raises(HomeAssistantError):
         await handler(call)
-
-
-# ── set_active_gear ───────────────────────────────────────────────────────────
 
 
 async def test_set_active_gear_by_uuid(mock_hass: MagicMock) -> None:
@@ -159,10 +165,53 @@ async def test_set_active_gear_by_entity_id(mock_hass: MagicMock) -> None:
         "setting": "set as default",
     }
 
-    await handler(call)
+    registry_entry = MagicMock()
+    registry_entry.config_entry_id = "entry_1"
+
+    with patch("custom_components.garmin_connect.services.er.async_get") as async_get:
+        async_get.return_value.async_get.return_value = registry_entry
+        await handler(call)
 
     client = _get_client(mock_hass)
     client.set_active_gear.assert_awaited_once_with(
+        activity_type="running",
+        setting="set as default",
+        gear_uuid="resolved-uuid",
+    )
+
+
+async def test_set_active_gear_by_entity_id_targets_entity_account(
+    mock_hass: MagicMock,
+) -> None:
+    """set_active_gear must use the account that owns the gear entity."""
+    second_entry = _make_entry("entry_2", "profile_2", "user2@example.com")
+    mock_hass.config_entries.async_entries.return_value.append(second_entry)
+
+    state = MagicMock()
+    state.attributes = {"gear_uuid": "resolved-uuid"}
+    mock_hass.states.get.return_value = state
+
+    registry_entry = MagicMock()
+    registry_entry.config_entry_id = "entry_2"
+
+    await async_setup_services(mock_hass)
+    handler = _get_handler(mock_hass, "set_active_gear")
+    first_client = _get_client_for_entry(mock_hass, "entry_1")
+    second_client = _get_client_for_entry(mock_hass, "entry_2")
+
+    call = MagicMock()
+    call.data = {
+        "entity_id": "sensor.second_garmin_shoes",
+        "activity_type": "running",
+        "setting": "set as default",
+    }
+
+    with patch("custom_components.garmin_connect.services.er.async_get") as async_get:
+        async_get.return_value.async_get.return_value = registry_entry
+        await handler(call)
+
+    first_client.set_active_gear.assert_not_awaited()
+    second_client.set_active_gear.assert_awaited_once_with(
         activity_type="running",
         setting="set as default",
         gear_uuid="resolved-uuid",
@@ -219,9 +268,6 @@ async def test_set_active_gear_entity_no_uuid_raises(mock_hass: MagicMock) -> No
         await handler(call)
 
 
-# ── add_body_composition ──────────────────────────────────────────────────────
-
-
 async def test_add_body_composition(mock_hass: MagicMock) -> None:
     """add_body_composition must call client with the supplied fields."""
     await async_setup_services(mock_hass)
@@ -244,6 +290,52 @@ async def test_add_body_composition(mock_hass: MagicMock) -> None:
     assert kwargs["muscle_mass"] == 35.0
 
 
+async def test_add_body_composition_targets_entity_config_entry(
+    mock_hass: MagicMock,
+) -> None:
+    """add_body_composition must target the account that owns entity_id."""
+    second_entry = _make_entry("entry_2", "profile_2", "user2@example.com")
+    mock_hass.config_entries.async_entries.return_value.append(second_entry)
+
+    registry_entry = MagicMock()
+    registry_entry.config_entry_id = "entry_2"
+
+    await async_setup_services(mock_hass)
+    handler = _get_handler(mock_hass, "add_body_composition")
+    first_client = _get_client_for_entry(mock_hass, "entry_1")
+    second_client = _get_client_for_entry(mock_hass, "entry_2")
+
+    call = MagicMock()
+    call.data = {
+        "entity_id": "sensor.second_garmin_weight",
+        "weight": 72.0,
+    }
+
+    with patch("custom_components.garmin_connect.services.er.async_get") as async_get:
+        async_get.return_value.async_get.return_value = registry_entry
+        await handler(call)
+
+    first_client.add_body_composition.assert_not_awaited()
+    second_client.add_body_composition.assert_awaited_once()
+    assert second_client.add_body_composition.call_args.kwargs["weight"] == 72.0
+
+
+async def test_add_body_composition_entity_not_found_raises(
+    mock_hass: MagicMock,
+) -> None:
+    """add_body_composition must raise when the requested entity is unknown."""
+    await async_setup_services(mock_hass)
+    handler = _get_handler(mock_hass, "add_body_composition")
+
+    call = MagicMock()
+    call.data = {"entity_id": "sensor.missing_weight", "weight": 80.0}
+
+    with patch("custom_components.garmin_connect.services.er.async_get") as async_get:
+        async_get.return_value.async_get.return_value = None
+        with pytest.raises(HomeAssistantError):
+            await handler(call)
+
+
 async def test_add_body_composition_api_error_raises(mock_hass: MagicMock) -> None:
     """add_body_composition must wrap API errors in HomeAssistantError."""
     await async_setup_services(mock_hass)
@@ -256,9 +348,6 @@ async def test_add_body_composition_api_error_raises(mock_hass: MagicMock) -> No
 
     with pytest.raises(HomeAssistantError):
         await handler(call)
-
-
-# ── add_blood_pressure ────────────────────────────────────────────────────────
 
 
 async def test_add_blood_pressure(mock_hass: MagicMock) -> None:
@@ -298,9 +387,6 @@ async def test_add_blood_pressure_wraps_exception(mock_hass: MagicMock) -> None:
 
     with pytest.raises(HomeAssistantError):
         await handler(call)
-
-
-# ── create_activity ───────────────────────────────────────────────────────────
 
 
 async def test_create_activity(mock_hass: MagicMock) -> None:
@@ -350,9 +436,6 @@ async def test_create_activity_defaults_to_now(mock_hass: MagicMock) -> None:
     assert ".000" in kwargs["start_datetime"]
 
 
-# ── upload_activity ───────────────────────────────────────────────────────────
-
-
 async def test_upload_activity(mock_hass: MagicMock, tmp_path: Path) -> None:
     """upload_activity must call client.upload_activity when the file exists."""
     await async_setup_services(mock_hass)
@@ -380,9 +463,6 @@ async def test_upload_activity_file_not_found_raises(mock_hass: MagicMock) -> No
 
     with pytest.raises(HomeAssistantError):
         await handler(call)
-
-
-# ── add_gear_to_activity ──────────────────────────────────────────────────────
 
 
 async def test_add_gear_to_activity_by_uuid(mock_hass: MagicMock) -> None:
@@ -415,7 +495,12 @@ async def test_add_gear_to_activity_by_entity(mock_hass: MagicMock) -> None:
     call = MagicMock()
     call.data = {"activity_id": 99999, "entity_id": "sensor.garmin_shoes"}
 
-    await handler(call)
+    registry_entry = MagicMock()
+    registry_entry.config_entry_id = "entry_1"
+
+    with patch("custom_components.garmin_connect.services.er.async_get") as async_get:
+        async_get.return_value.async_get.return_value = registry_entry
+        await handler(call)
 
     client.add_gear_to_activity.assert_awaited_once_with(
         gear_uuid="entity-uuid",
@@ -433,9 +518,6 @@ async def test_add_gear_to_activity_no_gear_raises(mock_hass: MagicMock) -> None
 
     with pytest.raises(HomeAssistantError):
         await handler(call)
-
-
-# ── add_hydration ─────────────────────────────────────────────────────────────
 
 
 async def test_add_hydration(mock_hass: MagicMock) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -182,7 +182,7 @@ async def test_set_active_gear_by_entity_id(mock_hass: MagicMock) -> None:
 
 async def test_set_active_gear_by_entity_id_targets_entity_account(
     mock_hass: MagicMock,
-) -> None:
+):
     """set_active_gear must use the account that owns the gear entity."""
     second_entry = _make_entry("entry_2", "profile_2", "user2@example.com")
     mock_hass.config_entries.async_entries.return_value.append(second_entry)
@@ -292,7 +292,7 @@ async def test_add_body_composition(mock_hass: MagicMock) -> None:
 
 async def test_add_body_composition_targets_entity_config_entry(
     mock_hass: MagicMock,
-) -> None:
+):
     """add_body_composition must target the account that owns entity_id."""
     second_entry = _make_entry("entry_2", "profile_2", "user2@example.com")
     mock_hass.config_entries.async_entries.return_value.append(second_entry)
@@ -322,7 +322,7 @@ async def test_add_body_composition_targets_entity_config_entry(
 
 async def test_add_body_composition_entity_not_found_raises(
     mock_hass: MagicMock,
-) -> None:
+):
     """add_body_composition must raise when the requested entity is unknown."""
     await async_setup_services(mock_hass)
     handler = _get_handler(mock_hass, "add_body_composition")


### PR DESCRIPTION
This PR restores the ability to target a specific Garmin account when calling the add_body_composition service.

Problem:
Since version 3.x, multi-account setups can no longer select which Garmin account receives body composition data.

Solution:
- reintroduce entity_id support in add_body_composition
- resolve the correct config entry via entity_registry
- keep backward compatibility by falling back to the first account

This fixes multi-account usage without introducing new API surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional entity selection for the add_body_composition service, allowing measurements to be assigned to a specific Garmin Connect account.

* **Removed Services**
  * ~~Removed the add_blood_pressure service.~~

* **Improvements**
  * Relaxed validation constraints on body composition measurement fields.
  * Simplified and clarified field labels for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->