### PR TITLE
Improve body composition entity selector

### DIFF
--- a/custom_components/garmin_connect/services.yaml
+++ b/custom_components/garmin_connect/services.yaml
@@ -42,11 +42,13 @@ add_body_composition:
   description: Upload a body composition measurement to Garmin Connect.
   fields:
     entity_id:
-      name: Garmin Connect entity
-      description: Optional Garmin Connect entity whose account should receive the measurement.
+      name: Garmin Connect weight entity
+      description: Optional Garmin Connect weight sensor whose account should receive the measurement.
       selector:
         entity:
           integration: garmin_connect
+          domain: sensor
+          device_class: weight
     weight:
       name: Weight (kg)
       description: Body weight in kilograms.


### PR DESCRIPTION
This PR improves the `add_body_composition` service selector by only showing relevant Garmin Connect weight entities.

Previously, all Garmin Connect entities were displayed, even though the service only needs an entity to resolve the correct account.

This change restricts the selector to:

- `domain: sensor`
- `device_class: weight`

This makes the Home Assistant service UI cleaner and avoids selecting unrelated Garmin entities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified the `add_body_composition` service labeling to explicitly indicate "Garmin Connect weight entity" instead of generic "Garmin Connect entity," and refined the entity selector to specifically filter and display only Garmin Connect weight sensors. These changes provide clearer guidance during setup and reduce configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->