### PR TITLE
Extend menstrual data sensors

### DIFF
--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -6,7 +6,6 @@ import datetime
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date as dt_date
-from datetime import timedelta
 from enum import StrEnum
 from typing import Any, cast
 
@@ -1333,12 +1332,64 @@ def _menstrual_day_summary(data: dict[str, Any]) -> dict[str, Any]:
     return (data.get("menstrualData") or {}).get("daySummary") or {}
 
 
+def _menstrual_day_log(data: dict[str, Any]) -> dict[str, Any]:
+    """Safely return menstrual dayLog dict."""
+    return (data.get("menstrualData") or {}).get("dayLog") or {}
+
+
+def _menstrual_cycle_phase_attributes(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract extensive cycle phase summary attributes."""
+    summary = _menstrual_day_summary(data)
+
+    return {
+        "cycle_start_date": summary.get("startDate"),
+        "day_in_cycle": summary.get("dayInCycle"),
+        "period_length": summary.get("periodLength"),
+        "cycle_type": summary.get("cycleType"),
+        "days_until_next_phase": summary.get("daysUntilNextPhase"),
+        "length_of_current_phase": summary.get("lengthOfCurrentPhase"),
+        "predicted_cycle_length": summary.get("predictedCycleLength"),
+    }
+
+
+def _menstrual_day_log_attributes(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract extensive daily log attributes."""
+    day_log = _menstrual_day_log(data)
+
+    attrs = {
+        "calendar_date": day_log.get("calendarDate"),
+        "symptoms": day_log.get("symptoms"),
+        "moods": day_log.get("moods"),
+        "discharge": day_log.get("discharge"),
+        "flow": day_log.get("flow"),
+        "notes": day_log.get("notes"),
+        "sex_drive": day_log.get("sexDrive"),
+        "sexual_activity": day_log.get("sexualActivity"),
+        "has_baby_movement": day_log.get("hasBabyMovement"),
+        "ovulation_day": day_log.get("ovulationDay"),
+    }
+
+    return {k: v for k, v in attrs.items() if v is not None}
+
+
 def _menstrual_calendar_summaries(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Safely return menstrual calendar cycleSummaries list."""
     return (data.get("menstrualCalendar") or {}).get("cycleSummaries") or []
 
 
-def _menstrual_next_predicted_cycle_start(data: dict[str, Any]) -> str | None:
+def _menstrual_cycle_start(data: dict[str, Any]) -> datetime.date | None:
+    """Return current cycle startDate."""
+    s = _menstrual_day_summary(data)
+    start = s.get("startDate")
+    if not start:
+        return None
+    try:
+        return datetime.datetime.strptime(start, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _menstrual_next_predicted_cycle_start(data: dict[str, Any]) -> datetime.date | None:
     """Return next predicted cycle startDate from calendar."""
     today = dt_date.today()
     for cycle in _menstrual_calendar_summaries(data):
@@ -1351,38 +1402,34 @@ def _menstrual_next_predicted_cycle_start(data: dict[str, Any]) -> str | None:
             except ValueError:
                 continue
             if d >= today:
-                return str(start)
+                return d
     return None
 
 
-def _menstrual_fertile_window_start(data: dict[str, Any]) -> str | None:
+def _menstrual_fertile_window_start(data: dict[str, Any]) -> datetime.date | None:
     """Compute fertile window start date from cycle start + offset."""
+    start_date = _menstrual_cycle_start(data)
+    if not start_date:
+        return None
     s = _menstrual_day_summary(data)
-    start = s.get("startDate")
     fw_start = s.get("fertileWindowStart")
-    if not start or not isinstance(fw_start, int):
+    if not isinstance(fw_start, int):
         return None
-    try:
-        start_date = datetime.datetime.strptime(start, "%Y-%m-%d").date()
-    except ValueError:
-        return None
-    return (start_date + timedelta(days=fw_start - 1)).isoformat()
+    return start_date + datetime.timedelta(days=fw_start - 1)
 
 
-def _menstrual_fertile_window_end(data: dict[str, Any]) -> str | None:
+def _menstrual_fertile_window_end(data: dict[str, Any]) -> datetime.date | None:
     """Compute fertile window end date from start + length."""
+    start_date = _menstrual_cycle_start(data)
+    if not start_date:
+        return None
     s = _menstrual_day_summary(data)
-    start = s.get("startDate")
     fw_start = s.get("fertileWindowStart")
     fw_len = s.get("lengthOfFertileWindow")
-    if not start or not isinstance(fw_start, int) or not isinstance(fw_len, int) or fw_len <= 0:
+    if not isinstance(fw_start, int) or not isinstance(fw_len, int) or fw_len <= 0:
         return None
-    try:
-        start_date = datetime.datetime.strptime(start, "%Y-%m-%d").date()
-    except ValueError:
-        return None
-    fertile_start = start_date + timedelta(days=fw_start - 1)
-    return (fertile_start + timedelta(days=fw_len - 1)).isoformat()
+    fertile_start = start_date + datetime.timedelta(days=fw_start - 1)
+    return fertile_start + datetime.timedelta(days=fw_len - 1)
 
 
 MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
@@ -1396,13 +1443,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
             if isinstance(_menstrual_day_summary(data).get("currentPhase"), int)
             else None
         ),
-        attributes_fn=lambda data: {
-            "cycle_start_date": _menstrual_day_summary(data).get("startDate"),
-            "day_in_cycle": _menstrual_day_summary(data).get("dayInCycle"),
-            "period_length": _menstrual_day_summary(data).get("periodLength"),
-            "cycle_type": _menstrual_day_summary(data).get("cycleType"),
-            "days_until_next_phase": _menstrual_day_summary(data).get("daysUntilNextPhase"),
-        },
+        attributes_fn=_menstrual_cycle_phase_attributes,
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualCycleDay",
@@ -1411,6 +1452,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         value_fn=lambda data: _menstrual_day_summary(data).get("dayInCycle"),
+        attributes_fn=_menstrual_day_log_attributes,
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualDaysUntilNextPhase",
@@ -1426,7 +1468,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         coordinator_type=CoordinatorType.MENSTRUAL,
         device_class=SensorDeviceClass.DATE,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: _menstrual_day_summary(data).get("startDate"),
+        value_fn=_menstrual_cycle_start,
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualNextPredictedCycleStart",

--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -6,6 +6,7 @@ import datetime
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date as dt_date
+from datetime import timedelta
 from enum import StrEnum
 from typing import Any, cast
 
@@ -1377,7 +1378,7 @@ def _menstrual_calendar_summaries(data: dict[str, Any]) -> list[dict[str, Any]]:
     return (data.get("menstrualCalendar") or {}).get("cycleSummaries") or []
 
 
-def _menstrual_cycle_start(data: dict[str, Any]) -> datetime.date | None:
+def _menstrual_cycle_start(data: dict[str, Any]) -> dt_date | None:
     """Return current cycle startDate."""
     s = _menstrual_day_summary(data)
     start = s.get("startDate")
@@ -1389,36 +1390,36 @@ def _menstrual_cycle_start(data: dict[str, Any]) -> datetime.date | None:
         return None
 
 
-def _menstrual_next_predicted_cycle_start(data: dict[str, Any]) -> datetime.date | None:
-    """Return next predicted cycle startDate from calendar."""
+def _menstrual_next_predicted_cycle_start(data: dict[str, Any]) -> dt_date | None:
+    """Return the closest next predicted cycle startDate from calendar."""
     today = dt_date.today()
-    for cycle in _menstrual_calendar_summaries(data):
-        if cycle.get("predictedCycle") is True:
-            start = cycle.get("startDate")
-            if not isinstance(start, str):
-                continue
-            try:
-                d = datetime.datetime.strptime(start, "%Y-%m-%d").date()
-            except ValueError:
-                continue
-            if d >= today:
-                return d
-    return None
+
+    def valid_future_dates():
+        for cycle in _menstrual_calendar_summaries(data):
+            if cycle.get("predictedCycle") is True and isinstance(cycle.get("startDate"), str):
+                try:
+                    d = datetime.datetime.strptime(cycle["startDate"], "%Y-%m-%d").date()
+                    if d >= today:
+                        yield d
+                except ValueError:
+                    pass
+
+    return min(valid_future_dates(), default=None)
 
 
-def _menstrual_fertile_window_start(data: dict[str, Any]) -> datetime.date | None:
+def _menstrual_fertile_window_start(data: dict[str, Any]) -> dt_date | None:
     """Compute fertile window start date from cycle start + offset."""
     start_date = _menstrual_cycle_start(data)
     if not start_date:
         return None
     s = _menstrual_day_summary(data)
     fw_start = s.get("fertileWindowStart")
-    if not isinstance(fw_start, int):
+    if not isinstance(fw_start, int) or fw_start <= 0:
         return None
-    return start_date + datetime.timedelta(days=fw_start - 1)
+    return start_date + timedelta(days=fw_start - 1)
 
 
-def _menstrual_fertile_window_end(data: dict[str, Any]) -> datetime.date | None:
+def _menstrual_fertile_window_end(data: dict[str, Any]) -> dt_date | None:
     """Compute fertile window end date from start + length."""
     start_date = _menstrual_cycle_start(data)
     if not start_date:
@@ -1426,10 +1427,15 @@ def _menstrual_fertile_window_end(data: dict[str, Any]) -> datetime.date | None:
     s = _menstrual_day_summary(data)
     fw_start = s.get("fertileWindowStart")
     fw_len = s.get("lengthOfFertileWindow")
-    if not isinstance(fw_start, int) or not isinstance(fw_len, int) or fw_len <= 0:
+    if (
+        not isinstance(fw_start, int)
+        or fw_start <= 0
+        or not isinstance(fw_len, int)
+        or fw_len <= 0
+    ):
         return None
-    fertile_start = start_date + datetime.timedelta(days=fw_start - 1)
-    return fertile_start + datetime.timedelta(days=fw_len - 1)
+    fertile_start = start_date + timedelta(days=fw_start - 1)
+    return fertile_start + timedelta(days=fw_len - 1)
 
 
 MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
@@ -1461,6 +1467,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         value_fn=lambda data: _menstrual_day_summary(data).get("daysUntilNextPhase"),
+        attributes_fn=lambda _: {},
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualCycleStart",
@@ -1469,6 +1476,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_registry_enabled_default=False,
         value_fn=_menstrual_cycle_start,
+        attributes_fn=lambda _: {},
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualNextPredictedCycleStart",
@@ -1477,6 +1485,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_registry_enabled_default=False,
         value_fn=_menstrual_next_predicted_cycle_start,
+        attributes_fn=lambda _: {},
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualFertileWindowStart",
@@ -1485,6 +1494,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_registry_enabled_default=False,
         value_fn=_menstrual_fertile_window_start,
+        attributes_fn=lambda _: {},
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualFertileWindowEnd",
@@ -1493,6 +1503,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATE,
         entity_registry_enabled_default=False,
         value_fn=_menstrual_fertile_window_end,
+        attributes_fn=lambda _: {},
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualPeriodLength",
@@ -1502,6 +1513,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         value_fn=lambda data: _menstrual_day_summary(data).get("periodLength"),
+        attributes_fn=lambda _: {},
     ),
     GarminConnectSensorEntityDescription(
         key="menstrualCycleType",
@@ -1509,6 +1521,7 @@ MENSTRUAL_CYCLE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
         coordinator_type=CoordinatorType.MENSTRUAL,
         entity_registry_enabled_default=False,
         value_fn=lambda data: _menstrual_day_summary(data).get("cycleType"),
+        attributes_fn=lambda _: {},
     ),
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,6 +372,13 @@ def mock_menstrual_data() -> dict:
                     "predictedCycle": False
                 },
                 {
+                    "startDate": "2026-03-05",
+                    "periodLength": 5,
+                    "educationContentMod": 12,
+                    "lutealPhaseStart": 12,
+                    "predictedCycle": True
+                },
+                {
                     "startDate": "2026-02-14",
                     "periodLength": 5,
                     "educationContentMod": 12,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def mock_client() -> Generator[MagicMock]:
         client.fetch_goals_data = AsyncMock(return_value=mock_goals_data())
         client.fetch_gear_data = AsyncMock(return_value=mock_gear_data())
         client.fetch_blood_pressure_data = AsyncMock(return_value=mock_blood_pressure_data())
-        client.fetch_menstrual_data = AsyncMock(return_value={})
+        client.fetch_menstrual_data = AsyncMock(return_value=mock_menstrual_data())
         yield client
 
 
@@ -304,4 +304,86 @@ def mock_blood_pressure_data() -> dict:
         "bpMeasurementTime": "2026-01-24T08:00:00",
         "bpCategory": 1,
         "bpCategoryName": "Normal",
+    }
+
+
+def mock_menstrual_data() -> dict:
+    """Sample data for MenstrualCoordinator."""
+    return {
+        "menstrualData": {
+            "daySummary": {
+                "startDate": "2026-01-20",
+                "dayInCycle": 18,
+                "periodLength": 4,
+                "currentPhase": 4,
+                "lengthOfCurrentPhase": 12,
+                "lengthOfFertileWindow": 7,
+                "daysUntilNextPhase": 10,
+                "predictedCycleLength": 28,
+                "educationContentMod": 11,
+                "fertileWindowStart": 2,
+                "lutealPhaseStart": 12,
+                "cycleType": "REGULAR",
+                "predictedCycle": False
+            },
+            "dayLog": {
+                "userProfilePk": 111111,
+                "calendarDate": "2026-06-01",
+                "symptoms": [
+                    "ACNE"
+                ],
+                "moods": [
+                    "FINE"
+                ],
+                "discharge": [
+                    "NO_DISCHARGE"
+                ],
+                "flow": "HEAVY",
+                "sexDrive": "LOW",
+                "sexualActivity": "PROTECTED",
+                "notes": "Some note",
+                "reportTimestamp": "2026-06-01T09:03:38.456",
+                "hasBabyMovement": False,
+                "ovulationDay": True
+            }
+        },
+        "menstrualCalendar": {
+            "cycleSummaries": [
+                {
+                    "startDate": "2025-11-29",
+                    "periodLength": 5,
+                    "fertileWindowStart": 9,
+                    "lengthOfFertileWindow": 5,
+                    "educationContentMod": 9,
+                    "predictedCycle": False
+                },
+                {
+                    "startDate": "2025-12-26",
+                    "periodLength": 4,
+                    "educationContentMod": 10,
+                    "lutealPhaseStart": 11,
+                    "predictedCycle": False
+                },
+                {
+                    "startDate": "2026-01-19",
+                    "periodLength": 6,
+                    "educationContentMod": 11,
+                    "lutealPhaseStart": 12,
+                    "predictedCycle": False
+                },
+                {
+                    "startDate": "2026-02-14",
+                    "periodLength": 5,
+                    "educationContentMod": 12,
+                    "lutealPhaseStart": 12,
+                    "predictedCycle": True
+                }
+            ],
+            "loggedSymptomDays": [
+                "2025-12-19",
+                "2026-01-25"
+            ],
+            "loggedOvulationDays": [],
+            "loggedNoteDays": []
+        }
     }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -418,6 +418,33 @@ def test_menstrual_cycle_start_returns_date_object() -> None:
     assert sensor.native_value == datetime.date.fromisoformat("2026-01-20")
 
 
+def test_menstrual_fertile_window_start_returns_none_when_fertile_window_start_is_less_than_or_zero() -> None:
+    """Menstrual fertile window start sensor must return None when fertileWindowStart <= 0"""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowStart")
+    coord = MagicMock()
+    coord.data = {
+        "menstrualData": {
+            "daySummary": {
+                "startDate": "2026-01-20",
+                "dayInCycle": 18,
+                "periodLength": 4,
+                "currentPhase": 4,
+                "lengthOfCurrentPhase": 12,
+                "lengthOfFertileWindow": 7,
+                "daysUntilNextPhase": 10,
+                "predictedCycleLength": 28,
+                "educationContentMod": 11,
+                "fertileWindowStart": 0,
+                "lutealPhaseStart": 12,
+                "cycleType": "REGULAR",
+                "predictedCycle": False
+            }
+        }
+    }
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value is None
+
+
 def test_menstrual_fertile_window_start_returns_none_when_missing() -> None:
     """Menstrual fertile window start sensor must return None when is absent."""
     desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowStart")
@@ -447,6 +474,60 @@ def test_menstrual_fertile_window_end_returns_none_when_missing() -> None:
     assert sensor.native_value is None
 
 
+def test_menstrual_fertile_window_end_returns_none_when_fertile_window_start_is_less_than_or_zero() -> None:
+    """Menstrual fertile window end sensor must return None when fertileWindowStart <= 0."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowEnd")
+    coord = MagicMock()
+    coord.data = {
+        "menstrualData": {
+            "daySummary": {
+                "startDate": "2026-01-20",
+                "dayInCycle": 18,
+                "periodLength": 4,
+                "currentPhase": 4,
+                "lengthOfCurrentPhase": 12,
+                "lengthOfFertileWindow": 7,
+                "daysUntilNextPhase": 10,
+                "predictedCycleLength": 28,
+                "educationContentMod": 11,
+                "fertileWindowStart": 0,
+                "lutealPhaseStart": 12,
+                "cycleType": "REGULAR",
+                "predictedCycle": False
+            }
+        }
+    }
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value is None
+
+
+def test_menstrual_fertile_window_end_returns_none_when_length_of_fertile_window_is_less_than_or_zero() -> None:
+    """Menstrual fertile window end sensor must return None when lengthOfFertileWindow <= 0."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowEnd")
+    coord = MagicMock()
+    coord.data = {
+        "menstrualData": {
+            "daySummary": {
+                "startDate": "2026-01-20",
+                "dayInCycle": 18,
+                "periodLength": 4,
+                "currentPhase": 4,
+                "lengthOfCurrentPhase": 12,
+                "lengthOfFertileWindow": 0,
+                "daysUntilNextPhase": 10,
+                "predictedCycleLength": 28,
+                "educationContentMod": 11,
+                "fertileWindowStart": 5,
+                "lutealPhaseStart": 12,
+                "cycleType": "REGULAR",
+                "predictedCycle": False
+            }
+        }
+    }
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value is None
+
+
 def test_menstrual_fertile_window_end_returns_date_object_when_present() -> None:
     """Menstrual fertile window end sensor must return a parsed date object, not a string."""
     import datetime
@@ -458,11 +539,44 @@ def test_menstrual_fertile_window_end_returns_date_object_when_present() -> None
     assert sensor.native_value == datetime.date.fromisoformat("2026-01-27")
 
 
-def test_menstrual_next_predicted_cycle_start_returns_none_when_missing() -> None:
-    """Menstrual next predicted cycle start sensor must return None when is absent."""
+@patch("custom_components.garmin_connect.sensor.dt_date")
+def test_menstrual_next_predicted_cycle_start_returns_none_when_missing(mock_date) -> None:
+    """Menstrual next predicted cycle start sensor must return None when predictedCycle entity is absent."""
+    import datetime
+
+    mock_date.today.return_value = datetime.date(2026, 1, 1)
+
     desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualNextPredictedCycleStart")
     coord = MagicMock()
-    coord.data = {}
+    coord.data = {
+        "menstrualData": {
+            "daySummary": {
+                "startDate": "2026-01-20",
+                "dayInCycle": 18,
+                "periodLength": 4,
+                "currentPhase": 4,
+                "lengthOfCurrentPhase": 12,
+                "daysUntilNextPhase": 10,
+                "predictedCycleLength": 28,
+                "educationContentMod": 11,
+                "lutealPhaseStart": 12,
+                "cycleType": "REGULAR",
+                "predictedCycle": False
+            }
+        },
+         "menstrualCalendar": {
+            "cycleSummaries": [
+                {
+                    "startDate": "2026-11-29",
+                    "periodLength": 5,
+                    "fertileWindowStart": 9,
+                    "lengthOfFertileWindow": 5,
+                    "educationContentMod": 9,
+                    "predictedCycle": False
+                }
+            ]
+        }
+    }
     sensor = GarminConnectSensor(coord, desc, "entry_id")
     assert sensor.native_value is None
 
@@ -478,7 +592,7 @@ def test_menstrual_next_predicted_cycle_start_returns_none_when_present_and_in_t
 
 @patch("custom_components.garmin_connect.sensor.dt_date")
 def test_menstrual_next_predicted_cycle_start_returns_date_object_when_present_and_in_future(mock_date) -> None:
-    """Menstrual next predicted cycle start sensor must return a parsed date object, not a string."""
+    """Menstrual next predicted cycle start sensor must return first predicted cycle >= today as date object."""
     import datetime
 
     mock_date.today.return_value = datetime.date(2026, 1, 1)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for Garmin Connect sensor platform."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from custom_components.garmin_connect.sensor import (
     _COORDINATOR_SENSOR_MAP,
@@ -23,6 +23,7 @@ from .conftest import (
     mock_body_data,
     mock_gear_data,
     mock_goals_data,
+    mock_menstrual_data,
     mock_training_data,
 )
 
@@ -404,6 +405,147 @@ def test_vo2_max_none_when_missing() -> None:
     coord.data = {}
     sensor = GarminConnectSensor(coord, desc, "entry_id")
     assert sensor.native_value is None
+
+
+def test_menstrual_cycle_start_returns_date_object() -> None:
+    """Menstrual cycle start sensor must return a parsed date object, not a string."""
+    import datetime
+
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualCycleStart")
+    coord = MagicMock()
+    coord.data = mock_menstrual_data()
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value == datetime.date.fromisoformat("2026-01-20")
+
+
+def test_menstrual_fertile_window_start_returns_none_when_missing() -> None:
+    """Menstrual fertile window start sensor must return None when is absent."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowStart")
+    coord = MagicMock()
+    coord.data = {}
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value is None
+
+
+def test_menstrual_fertile_window_start_returns_date_object_when_present() -> None:
+    """Menstrual fertile window start sensor must return a parsed date object, not a string."""
+    import datetime
+
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowStart")
+    coord = MagicMock()
+    coord.data = mock_menstrual_data()
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value == datetime.date.fromisoformat("2026-01-21")
+
+
+def test_menstrual_fertile_window_end_returns_none_when_missing() -> None:
+    """Menstrual fertile window end sensor must return None when is absent."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowEnd")
+    coord = MagicMock()
+    coord.data = {}
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value is None
+
+
+def test_menstrual_fertile_window_end_returns_date_object_when_present() -> None:
+    """Menstrual fertile window end sensor must return a parsed date object, not a string."""
+    import datetime
+
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualFertileWindowEnd")
+    coord = MagicMock()
+    coord.data = mock_menstrual_data()
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value == datetime.date.fromisoformat("2026-01-27")
+
+
+def test_menstrual_next_predicted_cycle_start_returns_none_when_missing() -> None:
+    """Menstrual next predicted cycle start sensor must return None when is absent."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualNextPredictedCycleStart")
+    coord = MagicMock()
+    coord.data = {}
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value is None
+
+
+def test_menstrual_next_predicted_cycle_start_returns_none_when_present_and_in_the_past() -> None:
+    """Menstrual next predicted cycle start sensor must return None when present but in the past."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualNextPredictedCycleStart")
+    coord = MagicMock()
+    coord.data = mock_menstrual_data()
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value is None
+
+
+@patch("custom_components.garmin_connect.sensor.dt_date")
+def test_menstrual_next_predicted_cycle_start_returns_date_object_when_present_and_in_future(mock_date) -> None:
+    """Menstrual next predicted cycle start sensor must return a parsed date object, not a string."""
+    import datetime
+
+    mock_date.today.return_value = datetime.date(2026, 1, 1)
+
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualNextPredictedCycleStart")
+    coord = MagicMock()
+    coord.data = mock_menstrual_data()
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value == datetime.date.fromisoformat("2026-02-14")
+
+
+def test_menstrual_cycle_day_attributes_return_empty_when_missing() -> None:
+    """Menstrual cycle day attributes must return empty when are absent."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualCycleDay")
+    coord = MagicMock()
+    coord.data = {
+        "menstrualData": {
+            "daySummary": {
+                "startDate": "2026-01-20",
+                "dayInCycle": 18,
+                "periodLength": 4,
+                "currentPhase": 4,
+                "lengthOfCurrentPhase": 12,
+                "daysUntilNextPhase": 10,
+                "predictedCycleLength": 28,
+                "educationContentMod": 11,
+                "lutealPhaseStart": 12,
+                "cycleType": "REGULAR",
+                "predictedCycle": False
+            }
+        }
+    }
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value == 18
+    assert sensor.extra_state_attributes == {}
+
+
+def test_menstrual_cycle_day_attributes_are_populated_when_present() -> None:
+    """Menstrual cycle day attributes must be correctly mapped from data."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualCycleDay")
+    coord = MagicMock()
+    coord.data = mock_menstrual_data()
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value == 18
+    attrs = sensor.extra_state_attributes
+    assert attrs["calendar_date"] == "2026-06-01"
+    assert attrs["symptoms"] == ["ACNE"]
+    assert attrs["moods"] == ["FINE"]
+    assert attrs["flow"] == "HEAVY"
+    assert attrs["notes"] == "Some note"
+    assert attrs["ovulation_day"] is True
+    assert attrs["has_baby_movement"] is False
+
+
+def test_menstrual_cycle_phase_attributes_are_populated() -> None:
+    """Menstrual cycle phase attributes must be correctly mapped from data."""
+    desc = next(d for d in MENSTRUAL_CYCLE_SENSORS if d.key == "menstrualCyclePhase")
+    coord = MagicMock()
+    coord.data = mock_menstrual_data()
+    sensor = GarminConnectSensor(coord, desc, "entry_id")
+    assert sensor.native_value == "Luteal"
+    attrs = sensor.extra_state_attributes
+    assert attrs["day_in_cycle"] == 18
+    assert attrs["period_length"] == 4
+    assert attrs["length_of_current_phase"] == 12
+    assert attrs["predicted_cycle_length"] == 28
+    assert attrs["cycle_type"] == "REGULAR"
 
 
 # ── GarminConnectGearSensor ───────────────────────────────────────────────────


### PR DESCRIPTION
- Add mock data and tests covering menstrual data sensors
- Fix date sensors -- set proper types (datetime instead of strings)
- Extend menstrualCycleDay with extra attributes (dayLog) -- not sure though if shouldn't have created a new sensor for storing this data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Menstrual tracking: sensors now provide parsed date objects for cycle starts and fertile window boundaries, safer daily-log access, richer cycle-phase and daily-log attributes, and improved next-predicted-cycle selection.
* **Tests**
  * Added comprehensive tests and test data for menstrual sensors covering date parsing, missing-data cases, predicted-cycle logic, and attribute population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->