### PR TITLE
fix: remove redundant blood pressure measurement time sensor

### DIFF
--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -1354,12 +1354,6 @@ BLOOD_PRESSURE_SENSORS: tuple[GarminConnectSensorEntityDescription, ...] = (
             if v is not None
         },
     ),
-    GarminConnectSensorEntityDescription(
-        key="bpMeasurementTime",
-        translation_key="bp_measurement_time",
-        coordinator_type=CoordinatorType.BLOOD_PRESSURE,
-        preserve_value=True,
-    ),
 )
 
 

--- a/custom_components/garmin_connect/strings.json
+++ b/custom_components/garmin_connect/strings.json
@@ -321,7 +321,7 @@
         "entity_id": { "name": "Garmin Connect entity", "description": "Optional Garmin Connect entity whose account owns the activity." },
         "activity_id": { "name": "Activity ID", "description": "Garmin activity ID (see last_activity sensor attributes)." },
         "file_format": { "name": "File format", "description": "fit (extracted from original zip), original (raw zip), tcx, gpx, kml or csv." },
-        "file_path": { "name": "File path", "description": "Target file or directory. Custom paths must be in allowlist_external_dirs. Defaults to <config>/garmin_activities/." }
+        "file_path": { "name": "File path", "description": "Target file or directory. Custom paths must be in allowlist_external_dirs. Defaults to [config]/garmin_activities/." }
       }
     },
     "upload_activity": {

--- a/custom_components/garmin_connect/strings.json
+++ b/custom_components/garmin_connect/strings.json
@@ -8,6 +8,7 @@
     "error": {
       "invalid_auth": "Invalid credentials",
       "invalid_mfa": "Invalid verification code",
+      "rate_limit": "Too many login attempts — Garmin is rate limiting. Please try again in a few minutes.",
       "unknown": "Unexpected error"
     },
     "step": {
@@ -24,11 +25,13 @@
       "reauth_confirm": {
         "data": {
           "password": "Password",
-          "username": "Email"
+          "username": "Email",
+          "is_cn": "Use Garmin Connect China (cn.garmin.com)"
         },
         "data_description": {
           "password": "Your Garmin Connect password",
-          "username": "Your Garmin Connect email address"
+          "username": "Your Garmin Connect email address",
+          "is_cn": "Enable for accounts registered on the Chinese Garmin Connect platform"
         },
         "description": "Enter your Garmin Connect credentials to re-authenticate.",
         "title": "Re-authenticate Integration"
@@ -36,11 +39,13 @@
       "reconfigure": {
         "data": {
           "password": "Password",
-          "username": "Email"
+          "username": "Email",
+          "is_cn": "Use Garmin Connect China (cn.garmin.com)"
         },
         "data_description": {
           "password": "Your Garmin Connect password",
-          "username": "Your Garmin Connect email address"
+          "username": "Your Garmin Connect email address",
+          "is_cn": "Enable for accounts registered on the Chinese Garmin Connect platform"
         },
         "description": "Update your Garmin Connect credentials.",
         "title": "Reconfigure Integration"
@@ -48,11 +53,13 @@
       "user": {
         "data": {
           "password": "Password",
-          "username": "Email"
+          "username": "Email",
+          "is_cn": "Use Garmin Connect China (cn.garmin.com)"
         },
         "data_description": {
           "password": "Your Garmin Connect password",
-          "username": "Your Garmin Connect email address"
+          "username": "Your Garmin Connect email address",
+          "is_cn": "Enable for accounts registered on the Chinese Garmin Connect platform"
         },
         "description": "Enter your Garmin Connect credentials."
       }
@@ -62,10 +69,12 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Update interval (seconds)"
+          "scan_interval": "Update interval (seconds)",
+          "is_cn": "Use Garmin Connect China (cn.garmin.com)"
         },
         "data_description": {
-          "scan_interval": "How often to fetch data from Garmin Connect (60–3600 seconds)"
+          "scan_interval": "How often to fetch data from Garmin Connect (60–3600 seconds)",
+          "is_cn": "Enable for accounts registered on the Chinese Garmin Connect platform"
         },
         "description": "Configure your Garmin Connect integration settings.",
         "title": "Garmin Connect Options"
@@ -99,7 +108,6 @@
       "bone_mass": { "name": "Bone mass" },
       "bp_category": { "name": "Blood pressure category" },
       "bp_diastolic": { "name": "Blood pressure diastolic" },
-      "bp_measurement_time": { "name": "Blood pressure measurement time" },
       "bp_pulse": { "name": "Blood pressure pulse" },
       "bp_systolic": { "name": "Blood pressure systolic" },
       "burned_calories": { "name": "Burned calories" },
@@ -246,6 +254,7 @@
       "name": "Add body composition",
       "description": "Add body composition metrics to Garmin Connect.",
       "fields": {
+        "entity_id": { "name": "Garmin Connect entity", "description": "Optional Garmin Connect entity whose account should receive the measurement." },
         "weight": { "name": "Weight", "description": "Weight in kilograms." },
         "timestamp": { "name": "Timestamp", "description": "When the measurement was recorded (defaults to now)." },
         "bmi": { "name": "BMI", "description": "Body Mass Index." },

--- a/custom_components/garmin_connect/translations/en.json
+++ b/custom_components/garmin_connect/translations/en.json
@@ -321,7 +321,7 @@
         "entity_id": { "name": "Garmin Connect entity", "description": "Optional Garmin Connect entity whose account owns the activity." },
         "activity_id": { "name": "Activity ID", "description": "Garmin activity ID (see last_activity sensor attributes)." },
         "file_format": { "name": "File format", "description": "fit (extracted from original zip), original (raw zip), tcx, gpx, kml or csv." },
-        "file_path": { "name": "File path", "description": "Target file or directory. Custom paths must be in allowlist_external_dirs. Defaults to <config>/garmin_activities/." }
+        "file_path": { "name": "File path", "description": "Target file or directory. Custom paths must be in allowlist_external_dirs. Defaults to [config]/garmin_activities/." }
       }
     },
     "upload_activity": {

--- a/custom_components/garmin_connect/translations/en.json
+++ b/custom_components/garmin_connect/translations/en.json
@@ -108,7 +108,6 @@
       "bone_mass": { "name": "Bone mass" },
       "bp_category": { "name": "Blood pressure category" },
       "bp_diastolic": { "name": "Blood pressure diastolic" },
-      "bp_measurement_time": { "name": "Blood pressure measurement time" },
       "bp_pulse": { "name": "Blood pressure pulse" },
       "bp_systolic": { "name": "Blood pressure systolic" },
       "burned_calories": { "name": "Burned calories" },

--- a/custom_components/garmin_connect/translations/pl.json
+++ b/custom_components/garmin_connect/translations/pl.json
@@ -158,9 +158,6 @@
       "bp_diastolic": {
         "name": "Ciśnienie rozkurczowe"
       },
-      "bp_measurement_time": {
-        "name": "Czas pomiaru ciśnienia"
-      },
       "bp_pulse": {
         "name": "Puls przy pomiarze ciśnienia"
       },

--- a/custom_components/garmin_connect/translations/zh-Hans.json
+++ b/custom_components/garmin_connect/translations/zh-Hans.json
@@ -108,7 +108,6 @@
       "bone_mass": { "name": "骨骼重量" },
       "bp_category": { "name": "血压类别" },
       "bp_diastolic": { "name": "舒张压" },
-      "bp_measurement_time": { "name": "血压测量时间" },
       "bp_pulse": { "name": "血压脉率" },
       "bp_systolic": { "name": "收缩压" },
       "burned_calories": { "name": "已消耗卡路里" },

--- a/custom_components/garmin_connect/translations/zh-Hans.json
+++ b/custom_components/garmin_connect/translations/zh-Hans.json
@@ -297,7 +297,7 @@
         "entity_id": { "name": "Garmin Connect 实体", "description": "可选：拥有该活动的 Garmin Connect 实体。" },
         "activity_id": { "name": "活动 ID", "description": "Garmin 活动 ID（见 last_activity 传感器属性）。" },
         "file_format": { "name": "文件格式", "description": "fit（从原始 zip 提取）、original（原始 zip）、tcx、gpx、kml 或 csv。" },
-        "file_path": { "name": "文件路径", "description": "目标文件或目录。自定义路径必须在 allowlist_external_dirs 中。默认为 <config>/garmin_activities/。" }
+        "file_path": { "name": "文件路径", "description": "目标文件或目录。自定义路径必须在 allowlist_external_dirs 中。默认为 [config]/garmin_activities/。" }
       }
     },
     "upload_activity": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -385,15 +385,6 @@ def test_bp_category_returns_name() -> None:
     assert sensor.native_value == "Normal"
 
 
-def test_bp_measurement_time_returns_string() -> None:
-    """bpMeasurementTime sensor must return the local measurement timestamp string."""
-    desc = next(d for d in BLOOD_PRESSURE_SENSORS if d.key == "bpMeasurementTime")
-    coord = MagicMock()
-    coord.data = mock_blood_pressure_data()
-    sensor = GarminConnectSensor(coord, desc, "entry_id")
-    assert sensor.native_value == "2026-01-24T08:00:00"
-
-
 def test_next_alarm_returns_first() -> None:
     """nextAlarm sensor must return a timezone-aware datetime parsed from the first alarm string."""
     import datetime


### PR DESCRIPTION
Measurement time is already exposed as the measurement_time attribute on the bpSystolic/bpDiastolic/bpPulse/bpCategoryName sensors, so the dedicated bpMeasurementTime sensor was redundant. Removed it and its translations.

Also add missing strings.json keys (rate_limit error, is_cn on all config steps + options, add_body_composition entity_id field) so strings.json matches translations/en.json and hassfest validation passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Removed the standalone “Blood pressure measurement time” sensor; the value is still available as an attribute on the blood pressure category sensor.
  - Added a user-facing message for Garmin login rate limiting.
  - Added an option to use Garmin Connect China during setup and reconfiguration.
  - Enhanced the body composition service to optionally select which Garmin Connect entity receives the measurement.
  - Updated the download activity `file_path` default path placeholder format.
- **Translations**
  - Removed the “bp_measurement_time” label from supported translation strings.
- **Tests**
  - Removed coverage for the former standalone measurement-time sensor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->