### PR TITLE
fix: keep the route polyline out of the recorder (#549)

### DIFF
--- a/custom_components/garmin_connect/sensor.py
+++ b/custom_components/garmin_connect/sensor.py
@@ -1825,6 +1825,10 @@ class GarminConnectSensor(CoordinatorEntity[BaseGarminCoordinator], SensorEntity
 
     entity_description: GarminConnectSensorEntityDescription
     _attr_has_entity_name = True
+    # The lastActivityRoute polyline is a full GPS track and blows past the recorder's
+    # hard 16 KiB attribute cap, which makes it drop the entity's attributes wholesale.
+    # Keep it live-only for the map card and templates; the rest still records.
+    _unrecorded_attributes = frozenset({"polyline"})
 
     def __init__(
         self,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for Garmin Connect sensor platform."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from custom_components.garmin_connect.sensor import (
@@ -833,3 +834,85 @@ def test_gear_sensor_unique_id_unnamed_gear_no_collision() -> None:
     assert sensor_a._attr_unique_id == "my_entry_gear_abc-123"
     assert sensor_b._attr_unique_id == "my_entry_gear_def-456"
     assert sensor_a._attr_unique_id != sensor_b._attr_unique_id
+
+
+# ── recorder: oversized route attributes (#549) ───────────────────────────────
+
+
+def _route_sensor(points: int) -> GarminConnectSensor:
+    """Build the real lastActivityRoute sensor over a polyline of N points."""
+    description = next(
+        d for d in ACTIVITY_TRACKING_SENSORS if d.key == "lastActivityRoute"
+    )
+    coord = MagicMock()
+    coord.data = {
+        "lastActivity": {
+            "polyline": [
+                {"lat": 19.4326 + i / 100000, "lon": -99.1332 + i / 100000}
+                for i in range(points)
+            ],
+            "hasPolyline": True,
+            "activityName": "Morning Ride",
+        }
+    }
+    return GarminConnectSensor(coord, description, "entry_id")
+
+
+def _recorded_attributes(sensor: GarminConnectSensor) -> bytes:
+    """Serialize the sensor state through the recorder's own encoder."""
+    from homeassistant.components.recorder.db_schema import StateAttributes
+    from homeassistant.const import EVENT_STATE_CHANGED
+    from homeassistant.core import Event, State
+
+    # Mirrors Entity.async_internal_added_to_hass, which publishes the union of the
+    # component-level and entity-level unrecorded attributes onto the state.
+    unrecorded = (
+        sensor._entity_component_unrecorded_attributes | sensor._unrecorded_attributes
+    )
+    state = State(
+        "sensor.garmin_connect_last_activity_route",
+        str(sensor.native_value),
+        sensor.extra_state_attributes,
+        state_info={"unrecorded_attributes": unrecorded},
+    )
+    event = Event(
+        EVENT_STATE_CHANGED,
+        {"entity_id": state.entity_id, "old_state": None, "new_state": state},
+    )
+    return StateAttributes.shared_attrs_bytes_from_event(event, None)
+
+
+def test_route_polyline_never_reaches_the_recorder() -> None:
+    """The polyline must be excluded from what the recorder persists (#549)."""
+    recorded = _recorded_attributes(_route_sensor(points=500))
+
+    # The `!= b"{}"` assert carries the weight: when the row blows the size cap the
+    # recorder drops every attribute, so checking only that the polyline is absent
+    # would pass on the unfixed code too — for the wrong reason.
+    assert recorded != b"{}"
+    # Compare keys, not raw bytes: "has_polyline" contains "polyline".
+    assert "polyline" not in json.loads(recorded)
+
+
+def test_route_recorded_attributes_stay_under_the_16kib_cap() -> None:
+    """Recorded attributes must fit the recorder's hard 16 KiB limit (#549)."""
+    recorded = _recorded_attributes(_route_sensor(points=2000))
+
+    assert recorded != b"{}"
+    assert len(recorded) < 16384
+
+
+def test_route_siblings_are_still_recorded() -> None:
+    """Dropping the polyline must not drop the sensor's other attributes (#549)."""
+    recorded = json.loads(_recorded_attributes(_route_sensor(points=500)))
+
+    assert recorded["has_polyline"] is True
+    assert recorded["activity_name"] == "Morning Ride"
+
+
+def test_route_polyline_remains_available_live() -> None:
+    """The polyline must stay on the live entity for the map card and templates."""
+    sensor = _route_sensor(points=10)
+
+    assert len(sensor.extra_state_attributes["polyline"]) == 10
+    assert sensor.native_value == 10


### PR DESCRIPTION
Fixes #549.

## Symptom

On a live instance the recorder refuses to store `sensor.garmin_connect_last_activity_route`:

```
State attributes for sensor.garmin_connect_last_activity_route exceed maximum
size of 16384 bytes. This can cause database performance issues;
Attributes will not be stored
```

The entity works fine in the UI, so this fails silently unless you go looking in the log.

## Cause

The sensor's state is the polyline **length**, while the full GPS track rides along as a state attribute. Any real activity pushes the serialized attributes past the recorder's hard 16 KiB cap — and when that happens the recorder discards **the whole attribute row**, so `has_polyline` and `activity_name` are lost too, not just the polyline.

## Change

Four lines: declare `polyline` as unrecorded on `GarminConnectSensor`.

```python
_unrecorded_attributes = frozenset({"polyline"})
```

`polyline` is only ever emitted by the `lastActivityRoute` description — `lastActivity` already filters it out — so the class-level declaration touches nothing else. It has to be class-level: HA computes the combined set in `Entity.__init_subclass__`, so a per-instance assignment would silently do nothing.

The polyline stays on the live entity, so `garmin-polyline-card.js` and any templates are unaffected. The other attributes now actually get recorded, which they weren't before.

## Validation

Tests go through the recorder's own encoder (`StateAttributes.shared_attrs_bytes_from_event`) rather than asserting on the declaration, so they measure the effect rather than the intent.

Two things worth flagging, because I got both wrong on the first pass:

- **The `!= b"{}"` assertion carries the weight.** A plain "polyline is absent from the recorded payload" check *passes on the unfixed code* — because the oversized row is emptied entirely, so nothing is in it. Without the non-empty assert the test proves nothing.
- **Keys are compared, not raw bytes** — `has_polyline` contains the substring `polyline`.

Against `main` with the fix reverted, 3 of the 4 new tests fail (the 4th guards live availability and passes either way, by design). With the fix: 132 passed, no regressions. `ruff check` clean.

Reproduced from the unfixed code, the test surfaces the exact warning from the issue:

```
WARNING homeassistant.components.recorder.db_schema:
State attributes for sensor.garmin_connect_last_activity_route exceed maximum size of 16384 bytes
```

## Not included

The issue also asked whether other sensors deserve the same treatment. `last_activities` and `last_workouts` both cap at 10 entries, and I have no measurement showing them crossing 16 KiB — so I left them alone rather than adding speculative exclusions. Happy to follow up if you've seen the warning on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large route data is no longer saved in historical records, reducing recorder storage size.
  * Route details remain available on the live sensor and in templates.
  * Other sensor attributes continue to be recorded normally.

* **Tests**
  * Added coverage to verify route data handling and recorder attribute limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->